### PR TITLE
Compile on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ distclean: clean
 
 package: server/epdfinfo
 	mkdir -p '$(PACKAGE_DIR)'
-	cp -u lisp/*.el README server/epdfinfo -t '$(PACKAGE_DIR)'
+	cp -f lisp/*.el README server/epdfinfo '$(PACKAGE_DIR)'
 	echo '$(PKGFILE_CONTENT)' > '$(PACKAGE_DIR)/pdf-tools-pkg.el'
 	tar cf '$(PACKAGE_NAME).tar' '$(PACKAGE_DIR)'
 

--- a/server/epdfinfo.c
+++ b/server/epdfinfo.c
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
+#include <stdbool.h>
 #include <assert.h>
 #include <err.h>
 #include <error.h>
@@ -36,6 +37,11 @@
 #include "synctex_parser.h"
 #include "epdfinfo.h"
 #include "config.h"
+
+#ifdef __APPLE__
+# define error printf
+#endif
+
 
 
 /* ================================================================== *

--- a/server/error.h
+++ b/server/error.h
@@ -1,0 +1,59 @@
+//========================================================================
+//
+// Error.h
+//
+// Copyright 1996-2003 Glyph & Cog, LLC
+//
+//========================================================================
+
+//========================================================================
+//
+// Modified under the Poppler project - http://poppler.freedesktop.org
+//
+// All changes made under the Poppler project to this file are licensed
+// under GPL version 2 or later
+//
+// Copyright (C) 2005, 2007 Jeff Muizelaar <jeff@infidigm.net>
+// Copyright (C) 2005 Albert Astals Cid <aacid@kde.org>
+// Copyright (C) 2005 Kristian Høgsberg <krh@redhat.com>
+// Copyright (C) 2013 Adrian Johnson <ajohnson@redneon.com>
+//
+// To see a description of the changes please see the Changelog file that
+// came with your tarball or type make ChangeLog if you are building from git
+//
+//========================================================================
+
+#ifndef ERROR_H
+#define ERROR_H
+
+#ifdef USE_GCC_PRAGMAS
+#pragma interface
+#endif
+
+#include <stdarg.h>
+#include "poppler-config.h"
+#include "goo/gtypes.h"
+
+enum ErrorCategory {
+  errSyntaxWarning,    // PDF syntax error which can be worked around;
+                       //   output will probably be correct
+  errSyntaxError,      // PDF syntax error which can be worked around;
+                       //   output will probably be incorrect
+  errConfig,           // error in Xpdf config info (xpdfrc file, etc.)
+  errCommandLine,      // error in user-supplied parameters, action not
+                       //   allowed, etc. (only used by command-line tools)
+  errIO,               // error in file I/O
+  errNotAllowed,       // action not allowed by PDF permission bits
+  errUnimplemented,    // unimplemented PDF feature - display will be
+                       //   incorrect
+  errInternal          // internal error - malfunction within the Xpdf code
+};
+
+typedef enum ErrorCategory ErrorCategory;
+extern void setErrorCallback(void (*cbk)(void *data, ErrorCategory category,
+					 Goffset pos, char *msg),
+			     void *data);
+
+extern void CDECL error(ErrorCategory category, Goffset pos, const char *msg, ...);
+
+#endif


### PR DESCRIPTION
* Apply diff from axot [[https://github.com/axot/pdf-tools/commit/4c33ea937eec6188837c021375e36a54958e5811]]
* changed options in cp in makefile to make it compatible with OSX's cp command

COMMENT:
It compiles with the following warnings (after setting the PKG_CONFIG variable). I do not know how serious the warnings and notes are and if they are specific to OSX. Also, I do not know if it compiles under linux with these changes.

````
10:08:43 {OSX} ~/Documents/Projects/pdf-tools$ make
cd server && ./autogen.sh
Running autoreconf...
configure.ac:6: installing './install-sh'
configure.ac:6: installing './missing'
Makefile.am: installing './depcomp'
cd server && ./configure -q

Is case-sensitive searching enabled ?     yes
Is modifying text annotations enabled ?   yes
Is modifying markup annotations enabled ? yes

/Applications/Xcode.app/Contents/Developer/usr/bin/make -C server
/Applications/Xcode.app/Contents/Developer/usr/bin/make  all-am
gcc -DHAVE_CONFIG_H -I.    -w -g -O2 -MT libsynctex_a-synctex_parser.o -MD -MP -MF .deps/libsynctex_a-synctex_parser.Tpo -c -o libsynctex_a-synctex_parser.o `test -f 'synctex_parser.c' || echo './'`synctex_parser.c
mv -f .deps/libsynctex_a-synctex_parser.Tpo .deps/libsynctex_a-synctex_parser.Po
gcc -DHAVE_CONFIG_H -I.    -w -g -O2 -MT libsynctex_a-synctex_parser_utils.o -MD -MP -MF .deps/libsynctex_a-synctex_parser_utils.Tpo -c -o libsynctex_a-synctex_parser_utils.o `test -f 'synctex_parser_utils.c' || echo './'`synctex_parser_utils.c
mv -f .deps/libsynctex_a-synctex_parser_utils.Tpo .deps/libsynctex_a-synctex_parser_utils.Po
rm -f libsynctex.a
ar cru libsynctex.a libsynctex_a-synctex_parser.o libsynctex_a-synctex_parser_utils.o 
ranlib libsynctex.a
gcc -DHAVE_CONFIG_H -I.    -I/usr/local/Cellar/glib/2.42.1/include/glib-2.0 -I/usr/local/Cellar/glib/2.42.1/lib/glib-2.0/include -I/usr/local/opt/gettext/include  -D_REENTRANT -I/usr/local/Cellar/poppler/0.29.0/include/poppler/glib -I/usr/local/Cellar/poppler/0.29.0/include/poppler -I/usr/local/Cellar/cairo/1.14.0/include/cairo -I/usr/local/Cellar/glib/2.42.1/include/glib-2.0 -I/usr/local/Cellar/glib/2.42.1/lib/glib-2.0/include -I/usr/local/opt/gettext/include -I/usr/local/Cellar/pixman/0.32.6/include/pixman-1 -I/usr/local/Cellar/fontconfig/2.11.1/include -I/usr/local/Cellar/freetype/2.5.3_1/include/freetype2 -I/usr/local/Cellar/freetype/2.5.5/include/freetype2 -I/usr/local/Cellar/libpng/1.6.16/include/libpng16 -I/opt/X11/include  -I/usr/local/Cellar/poppler/0.29.0/include/poppler  -I/usr/local/Cellar/libpng/1.6.16/include/libpng16  -g -O2 -MT epdfinfo-epdfinfo.o -MD -MP -MF .deps/epdfinfo-epdfinfo.Tpo -c -o epdfinfo-epdfinfo.o `test -f 'epdfinfo.c' || echo './'`epdfinfo.c
epdfinfo.c:274:19: warning: 'tempnam' is deprecated: This function is provided for compatibility reasons only.
      Due to security concerns inherent in the design of tempnam(3), it is highly recommended that you use
      mkstemp(3) instead. [-Wdeprecated-declarations]
      filename =  tempnam(NULL, "epdfinfo");
                  ^
/usr/include/stdio.h:391:7: note: 'tempnam' has been explicitly marked deprecated here
char    *tempnam(const char *, const char *) __DARWIN_ALIAS(tempnam);
         ^
epdfinfo.c:470:7: warning: incompatible integer to pointer conversion passing 'int' to parameter of type
      'const char *' [-Wint-conversion]
      internal_error ("switch fell through");
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./epdfinfo.h:103:10: note: expanded from macro 'internal_error'
  error (2, 0, "internal error in %s: " fmt, __func__, ## args)
         ^
/usr/include/stdio.h:259:36: note: passing argument to parameter here
int      printf(const char * __restrict, ...) __printflike(1, 2);
                                       ^
epdfinfo.c:819:7: warning: incompatible integer to pointer conversion passing 'int' to parameter of type
      'const char *' [-Wint-conversion]
      internal_error ("switch fell through");
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./epdfinfo.h:103:10: note: expanded from macro 'internal_error'
  error (2, 0, "internal error in %s: " fmt, __func__, ## args)
         ^
/usr/include/stdio.h:259:36: note: passing argument to parameter here
int      printf(const char * __restrict, ...) __printflike(1, 2);
                                       ^
3 warnings generated.
mv -f .deps/epdfinfo-epdfinfo.Tpo .deps/epdfinfo-epdfinfo.Po
g++ -DHAVE_CONFIG_H -I.    -I/usr/local/Cellar/glib/2.42.1/include/glib-2.0 -I/usr/local/Cellar/glib/2.42.1/lib/glib-2.0/include -I/usr/local/opt/gettext/include  -D_REENTRANT -I/usr/local/Cellar/poppler/0.29.0/include/poppler/glib -I/usr/local/Cellar/poppler/0.29.0/include/poppler -I/usr/local/Cellar/cairo/1.14.0/include/cairo -I/usr/local/Cellar/glib/2.42.1/include/glib-2.0 -I/usr/local/Cellar/glib/2.42.1/lib/glib-2.0/include -I/usr/local/opt/gettext/include -I/usr/local/Cellar/pixman/0.32.6/include/pixman-1 -I/usr/local/Cellar/fontconfig/2.11.1/include -I/usr/local/Cellar/freetype/2.5.3_1/include/freetype2 -I/usr/local/Cellar/freetype/2.5.5/include/freetype2 -I/usr/local/Cellar/libpng/1.6.16/include/libpng16 -I/opt/X11/include  -I/usr/local/Cellar/poppler/0.29.0/include/poppler  -I/usr/local/Cellar/libpng/1.6.16/include/libpng16  -g -O2 -MT epdfinfo-poppler-hack.o -MD -MP -MF .deps/epdfinfo-poppler-hack.Tpo -c -o epdfinfo-poppler-hack.o `test -f 'poppler-hack.cc' || echo './'`poppler-hack.cc
mv -f .deps/epdfinfo-poppler-hack.Tpo .deps/epdfinfo-poppler-hack.Po
g++ -I/usr/local/Cellar/glib/2.42.1/include/glib-2.0 -I/usr/local/Cellar/glib/2.42.1/lib/glib-2.0/include -I/usr/local/opt/gettext/include  -D_REENTRANT -I/usr/local/Cellar/poppler/0.29.0/include/poppler/glib -I/usr/local/Cellar/poppler/0.29.0/include/poppler -I/usr/local/Cellar/cairo/1.14.0/include/cairo -I/usr/local/Cellar/glib/2.42.1/include/glib-2.0 -I/usr/local/Cellar/glib/2.42.1/lib/glib-2.0/include -I/usr/local/opt/gettext/include -I/usr/local/Cellar/pixman/0.32.6/include/pixman-1 -I/usr/local/Cellar/fontconfig/2.11.1/include -I/usr/local/Cellar/freetype/2.5.3_1/include/freetype2 -I/usr/local/Cellar/freetype/2.5.5/include/freetype2 -I/usr/local/Cellar/libpng/1.6.16/include/libpng16 -I/opt/X11/include  -I/usr/local/Cellar/poppler/0.29.0/include/poppler  -I/usr/local/Cellar/libpng/1.6.16/include/libpng16  -g -O2   -o epdfinfo epdfinfo-epdfinfo.o epdfinfo-poppler-hack.o -L/usr/local/Cellar/glib/2.42.1/lib -L/usr/local/opt/gettext/lib -lglib-2.0 -lintl  -L/usr/local/Cellar/poppler/0.29.0/lib -L/usr/local/Cellar/glib/2.42.1/lib -L/usr/local/opt/gettext/lib -L/usr/local/Cellar/cairo/1.14.0/lib -lpoppler-glib -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lintl -lcairo  -L/usr/local/Cellar/poppler/0.29.0/lib -lpoppler  -L/usr/local/Cellar/libpng/1.6.16/lib -lpng16  libsynctex.a -L/usr/local/Cellar/zlib/1.2.8/lib -lz  
mkdir -p 'pdf-tools-0.50'
cp -f lisp/*.el README server/epdfinfo 'pdf-tools-0.50'
echo '(define-package "pdf-tools" "0.50" "Support library for PDF documents." (quote ((emacs "24.3"))) :keywords (quote ("files" "multimedia")))' > 'pdf-tools-0.50/pdf-tools-pkg.el'
tar cf 'pdf-tools-0.50.tar' 'pdf-tools-0.50'
10:08:55 {OSX} ~/Documents/Projects/pdf-tools$ 
````