### PR TITLE
Allow reusing other frame in pdf-sync-forward-search

### DIFF
--- a/lisp/pdf-sync.el
+++ b/lisp/pdf-sync.el
@@ -674,7 +674,7 @@ Needs to have `pdf-sync-backward-debug-minor-mode' enabled."
     (let ((buffer (or (find-buffer-visiting pdf)
                       (find-file-noselect pdf))))
       (with-selected-window (display-buffer
-                             buffer pdf-sync-forward-display-action)
+                             buffer pdf-sync-forward-display-action t)
         (pdf-util-assert-pdf-window)
         (pdf-view-goto-page page)
         (let ((top (* y1 (cdr (pdf-view-image-size)))))


### PR DESCRIPTION
When writing a document with AUCTeX I usually dedicate a frame to viewing the generated PDF.  However, AUCTeX View command calls `pdf-sync-forward-search` which forcefully opens the document in a window of the current frame.  This micro-patch allows `display-buffer` to reuse an existing frame in case the pdf is already shown there.