### PR TITLE
Recolor

### DIFF
--- a/README.org
+++ b/README.org
@@ -47,6 +47,18 @@
 *** SyncTeX
     Jump from a position on a page directly to the TeX source and
     vice-versa.
+*** Recolor
+    It is possible to process the colors of the page before it is
+    displayed, which is useful in certain cases (such as reading in
+    low light conditions.) This is an example that switches black and
+    white:
+#+begin_src elisp
+(add-hook 'pdf-tools-enabled-hook
+	   (lambda ()
+	     (pdf-info-setoptions :render/usecolors t
+		                  :render/foreground "white"
+		                  :render/background "black")))
+#+end_src
 *** Misc
    + Display PDF's metadata.
    + Mark a region and kill the text from the PDF.

--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -462,8 +462,7 @@ interrupted."
     ((save) (caar response))
     ((renderpage renderpage-text-regions renderpage-highlight)
      (pdf-util-munch-file (caar response)))
-    (setoptions nil)
-    (getoptions
+    ((setoptions getoptions)
      (let (options)
        (dolist (key-value response)
          (let ((key (intern (car key-value)))
@@ -473,7 +472,7 @@ interrupted."
               (setq value (equal value "1"))))
            (push value options)
            (push key options)))
-       options))                 
+       options))
     (t response)))
 
 

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -885,6 +885,14 @@ This tells the various modes to use their face's dark colors."
       (pdf-isearch-message
        (if pdf-view-dark-minor-mode "dark mode" "light mode")))))
 
+(define-minor-mode pdf-view-printer-minor-mode
+  "Display the PDF as it would be printed."
+  nil nil nil
+  (pdf-util-assert-pdf-buffer)
+  (pdf-info-setoptions :render/printed pdf-view-printer-minor-mode)
+  (pdf-cache-clear-images) 
+  (pdf-view-redisplay t))
+
 
 ;; * ================================================================== *
 ;; * Hotspot handling

--- a/server/epdfinfo.c
+++ b/server/epdfinfo.c
@@ -287,6 +287,64 @@ mktempfile()
   return filename;
 }
 
+static void
+image_recolor(cairo_surface_t* surface, const render_options_t *options)
+{
+  /* uses a representation of a rgb color as follows:
+     - a lightness scalar (between 0,1), which is a weighted average of r, g, b,
+     - a hue vector, which indicates a radian direction from the grey axis,
+       inside the equal lightness plane.
+     - a saturation scalar between 0,1. It is 0 when grey, 1 when the color is
+       in the boundary of the rgb cube.
+  */
+
+  const unsigned int page_width = cairo_image_surface_get_width (surface);
+  const unsigned int page_height = cairo_image_surface_get_height (surface);
+  const int rowstride  = cairo_image_surface_get_stride(surface);
+  unsigned char* image = cairo_image_surface_get_data(surface);
+
+  /* RGB weights for computing lightness. Must sum to one */
+  static const double a[] = {0.30, 0.59, 0.11};
+
+  const double f = 65535.;
+  const double rgb1[] = {
+    options->fg.red/f, options->fg.green/f, options->fg.blue/f
+  };
+  const double rgb2[] = {
+    options->bg.red/f, options->bg.green/f, options->bg.blue/f
+  };
+
+  const double rgb_diff[] = {
+    rgb2[0] - rgb1[0],
+    rgb2[1] - rgb1[1],
+    rgb2[2] - rgb1[2]
+  };
+
+  unsigned int y;
+  for (y = 0; y < page_height * rowstride; y += rowstride) {
+    unsigned char* data = image + y;
+
+    unsigned int x;
+    for (x = 0; x < page_width; x++, data += 4) {
+      /* Careful. data color components blue, green, red. */
+      const double rgb[3] = {
+        (double) data[2] / 256.,
+        (double) data[1] / 256.,
+        (double) data[0] / 256.
+      };
+
+      /* compute h, s, l data   */
+      double l = a[0]*rgb[0] + a[1]*rgb[1] + a[2]*rgb[2];
+
+      /* linear interpolation between dark and light with color ligtness as
+       * a parameter */
+      data[2] = (unsigned char)round(255.*(l * rgb_diff[0] + rgb1[0]));
+      data[1] = (unsigned char)round(255.*(l * rgb_diff[1] + rgb1[1]));
+      data[0] = (unsigned char)round(255.*(l * rgb_diff[2] + rgb1[2]));
+    }
+  }
+}
+
 /**
  * Render a PDF page.
  *
@@ -355,7 +413,7 @@ image_render_page(PopplerDocument *pdf, PopplerPage *page,
   cairo_paint (cr);
 
   if (options && options->usecolors)
-    ;/* image_recolor (cr); */
+    image_recolor (surface, options);
   
   cairo_destroy (cr);
 

--- a/server/epdfinfo.h
+++ b/server/epdfinfo.h
@@ -149,6 +149,18 @@ typedef struct
 
 typedef struct
 {
+  PopplerColor bg, fg;
+  gboolean usecolors;
+  gboolean printed;
+} render_options_t;
+
+typedef struct
+{
+  render_options_t render;
+} document_options_t;
+
+typedef struct
+{
   PopplerDocument *pdf;
   char *filename;
   char *passwd;
@@ -157,6 +169,7 @@ typedef struct
     GHashTable *keys;             /* key => page */
     GList **pages;                /* page array  */
   } annotations;
+  document_options_t options;
 } document_t;
 
 typedef enum

--- a/server/epdfinfo.h
+++ b/server/epdfinfo.h
@@ -137,6 +137,19 @@
       }                                                         \
   } while (0)
 
+/* Declare commands */
+#define DEC_CMD(name)                            \
+  {#name, cmd_ ## name, cmd_ ## name ## _spec,  \
+   G_N_ELEMENTS (cmd_ ## name ## _spec)}
+
+#define DEC_CMD2(command, name)                          \
+  {name, cmd_ ## command, cmd_ ## command ## _spec,     \
+   G_N_ELEMENTS (cmd_ ## command ## _spec)}
+
+/* Declare option */
+#define DEC_DOPT(name, type, sname)                      \
+  {name, type, offsetof (document_options_t, sname)}
+
 enum suffix_char { NONE, COLON, NEWLINE};
 
 enum image_type { PPM, PNG };
@@ -146,6 +159,29 @@ typedef struct
   PopplerAnnotMapping *amap;
   gchar *key;
 } annotation_t;
+
+typedef enum
+  {
+    ARG_INVALID = 0,
+    ARG_DOC,
+    ARG_BOOL,
+    ARG_STRING,
+    ARG_NONEMPTY_STRING,
+    ARG_NATNUM,
+    ARG_EDGE,
+    ARG_EDGE_OR_NEGATIVE,
+    ARG_EDGES,
+    ARG_EDGES_OR_POSITION,
+    ARG_COLOR,
+    ARG_REST
+  } command_arg_type_t;
+
+typedef struct
+{
+  const char *name; 
+  command_arg_type_t type;
+  size_t offset;
+} document_option_t;
 
 typedef struct
 {
@@ -171,25 +207,6 @@ typedef struct
   } annotations;
   document_options_t options;
 } document_t;
-
-typedef enum
-  {
-    ARG_INVALID = 0,
-    ARG_DOC,
-    ARG_BOOL,
-    ARG_STRING,
-    ARG_NONEMPTY_STRING,
-    ARG_NATNUM,
-    ARG_EDGE,
-    ARG_EDGE_OR_NEGATIVE,
-    ARG_EDGES,
-    ARG_EDGES_OR_POSITION,
-    ARG_COLOR,
-#ifdef HAVE_POPPLER_ANNOT_MARKUP
-    ARG_QUADRILATERAL,
-#endif
-    ARG_REST
-  } command_arg_type_t;
 
 typedef struct
 {


### PR DESCRIPTION
This is based on the `options` branch, which is not merged into `master` yet AFAIK.

One caveat with using `pdf-tools-setoptions` is that the change is not effective for the currently displayed page (if any). You need to redisplay the page somehow to see the changes. It works with the example added to `README.org` though, because the hook runs before the display.