### PR TITLE
Minor printing enhancements

### DIFF
--- a/lisp/pdf-misc.el
+++ b/lisp/pdf-misc.el
@@ -241,6 +241,14 @@ It is called with one argument, the PDF file."
   :group 'pdf-misc
   :type 'file)
 
+(defcustom pdf-misc-print-programm-args ""
+  "Arguments passed to pdf-misc-print-programm.
+
+Should be the empty string, rather than nil,
+when no arguments are passed."
+  :group 'pdf-misc
+  :type 'file)
+
 (defun pdf-misc-print-programm (&optional interactive-p)
   (or (and pdf-misc-print-programm
            (executable-find pdf-misc-print-programm))
@@ -267,8 +275,9 @@ It is called with one argument, the PDF file."
   (let ((programm (pdf-misc-print-programm interactive-p)))
     (unless programm
       (error "No print programm available"))
-    (start-process "printing" nil programm filename)
-    (message "print job sent!")))
+    (start-process "printing" nil programm pdf-misc-print-programm-args filename)
+    (message "print job sent as: %s %s %s"
+             programm pdf-misc-print-programm-args filename)))
 
 (provide 'pdf-misc)
 

--- a/lisp/pdf-misc.el
+++ b/lisp/pdf-misc.el
@@ -263,7 +263,8 @@ It is called with one argument, the PDF file."
   (let ((programm (pdf-misc-print-programm interactive-p)))
     (unless programm
       (error "No print programm available"))
-    (start-process "printing" nil programm filename)))
+    (start-process "printing" nil programm filename)
+    (message "print job sent!")))
 
 (provide 'pdf-misc)
 

--- a/lisp/pdf-misc.el
+++ b/lisp/pdf-misc.el
@@ -230,6 +230,10 @@
       (display-buffer (current-buffer)))
     md))
 
+(defgroup pdf-misc nil
+  "Miscellaneous options for PDF documents."
+  :group 'pdf-tools)
+
 (defcustom pdf-misc-print-programm nil
   "The program used for printing.
 


### PR DESCRIPTION
Three small tweaks to the printing interface in pdf-misc:

- added a new variable, pdf-misc-print-programm-args, to allow the user to pass additional arguments to the external program used to print pdfs

- added a new customize group, pdf-misc, so that the customization variables for printing are discoverable by users. This might better be called pdf-printing, but for consistency with the other groups/files I used pdf-misc.

- added a message in the minibuffer when a print job is sent. At present, there is no feedback to the user to indicate that a print job was sent, which is very useful when the printer is in a different room!

Thanks,

Tyler