### PR TITLE
Import/export annotations to org file.

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -1641,6 +1641,89 @@ belong to the same page and A1 is displayed above/left of A2."
             pdf-annot-list-document-buffer
             (pdf-annot-getannot id pdf-annot-list-document-buffer)))))
 
+(defconst pdf-annot-org-exportable-properties
+  (list 'page 'edges 'type 'id 'flags 'color 'modified 'label 'subject 'opacity 'created 'markup-edges 'icon))
+;; some properties are not changeable by default.
+;; we miss some information when importing, such as creation date.
+(defconst pdf-annot-org-importable-properties
+  (list 'contents 'edges 'flags 'color 'label 'opacity 'icon))
+
+(defun pdf-annot-export-to-org ()
+  "Export annotations to an Org file."
+  (interactive)
+  (let ((annots (sort (pdf-annot-getannots) 'pdf-annot-compare-annotations))
+        (filename (format "%s.org"
+                          (file-name-sans-extension
+                           (buffer-name)))))
+    (with-temp-buffer
+      (insert (concat "#+TITLE: Notes for " (file-name-sans-extension filename)))
+      (mapc
+       (lambda (annot) ;; traverse all annotations
+         (progn
+           (org-insert-heading-respect-content)
+           (insert (symbol-name (pdf-annot-get-id annot)))
+           (insert (concat "\n" (pdf-annot-get annot 'contents)))
+           (mapcar
+            '(lambda (field) ;; traverse all fields
+               (when (member (car field) pdf-annot-org-exportable-properties)
+                 (org-set-property (symbol-name (car field))
+                                   (format "%s" (cdr field)))))
+            annot)))
+       annots)
+      (write-file filename t))))
+
+(defun pdf-annot-import-from-org (orgfile)
+  "Import annotations from an Org file."
+  (interactive (list (ido-read-file-name "Org file to import from: ")))
+  (let ((pdfbuffer (current-buffer)))
+    (save-window-excursion
+      (find-file orgfile)
+      (goto-char (point-min))
+      (org-next-visible-heading 1)
+      (while (/= (point) (buffer-end 1)) ;; traverse org file
+        (let ((properties (list)))
+          ;; build list of properties
+          (mapc
+           (lambda (x)
+             (let ((propname (intern (downcase (car x)))) (propval (cdr x)))
+               (when (member propname pdf-annot-org-exportable-properties)
+                 (push
+                  (cons propname
+                        (cond ;; convert from string to proper types
+                         ((member propname (list 'page 'flags 'opacity)) (string-to-number propval))
+                         ((member propname (list 'type 'id)) (intern propval))
+                         ((string-equal propval "nil") nil)
+                         ((member propname (list 'edges 'modified))
+                          (mapcar 'string-to-number (split-string propval " \\|(\\|)" t)))
+                         ;; markup-edges is a list of lists of 4
+                         ((member propname (list 'markup-edges))
+                          (mapcar (lambda (x)
+                                    (mapcar 'string-to-number (split-string x " \\|(\\|)" t)))
+                                  (split-string propval "\) \(")))
+                         (t propval)))
+                  properties))))
+           (org-entry-properties))
+          ;; add contents -- they are the subtree text, after the properties
+          (push (cons 'contents
+                      (let ((beg (save-excursion (re-search-forward ":END:\n") (point)))
+                            (end (save-excursion (org-next-visible-heading 1) (point))))
+                        (buffer-substring-no-properties beg end)))
+                properties)
+          ;; add annotation
+          (with-current-buffer pdfbuffer
+            (pdf-annot-add-annotation (pdf-annot-get properties 'type)
+                                      (if (eq (pdf-annot-get properties 'type) 'text)
+                                          (pdf-annot-get properties 'edges)
+                                        (pdf-annot-get properties 'markup-edges))
+                                      (delq nil (mapcar
+                                                 (lambda (x)
+                                                   (if (member (car x) pdf-annot-org-importable-properties)
+                                                       x nil))
+                                                 properties))
+                                      (pdf-annot-get properties 'page)))
+          (org-next-visible-heading 1))))))
+
+
 (define-minor-mode pdf-annot-list-follow-minor-mode
   "" nil nil nil
   (unless (derived-mode-p 'pdf-annot-list-mode)

--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -1683,7 +1683,16 @@ are referenced by its edges, but functions for these tasks need region."
            (org-insert-heading-respect-content)
            (insert (symbol-name (pdf-annot-get-id annot)))
            (insert (concat " :" (symbol-name (pdf-annot-get-type annot)) ":"))
-           (insert (concat "\n" (pdf-annot-get annot 'contents)))
+           ;; insert text from marked-up region in an org-mode quote
+           (when (pdf-annot-get annot 'markup-edges)
+             (insert (concat "\n#+BEGIN_QUOTE\n"
+                             (with-current-buffer buffer
+                               (pdf-info-gettext (pdf-annot-get annot 'page)
+                                                 (pdf-annot-edges-to-region
+                                                  (pdf-annot-get annot 'markup-edges))))
+                             "\n#+END_QUOTE")))
+           (insert (concat "\n\n" (pdf-annot-get annot 'contents)))
+           ;; set org properties for each of the remaining fields
            (mapcar
             '(lambda (field) ;; traverse all fields
                (when (member (car field) pdf-annot-org-exportable-properties)


### PR DESCRIPTION
This allows to export/import the PDF annotations to/from an org file.
Some information (such as created/modified time) may be missing after
an import, but the contents, type, color, and positions are working.

The motivation is to be able to keep my notes apart from the pdfs, in order to easily backup and version control them. Besides, I'm using org-ref to manage bibliography; it allows quick access to org note files  from any source, so it makes sense to use pdf-tools to do generate these files. 

Known issues: 
- importer seems to merge multiple markup annotations in one when they're close to each other. 

Future work (I plan to work on these when I find the time):
- make the annotation type a tag in the org file
- capture text of markup annotations and add it to the org file