### PR TITLE
correct "it's/its" grammar in docstrings

### DIFF
--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -722,7 +722,7 @@ representing the final page."
 
 All queries in each QUERIES form are run by the server in the
 order they appear and the results collected in a list, which is
-bound to VAR.  Then BODY is evaluated and it's value becomes the
+bound to VAR.  Then BODY is evaluated and its value becomes the
 final result of all queries, unless at least one of them provoked
 an error.  In this case BODY is ignored and the error is the
 result.
@@ -797,7 +797,7 @@ i.e. `pdf-info-asynchronous' is non-nil, transparently.
                        (funcall ,callback ,status ,response)
                      (apply (car ,callback)
                        ,status ,response (cdr ,callback))))))))
-       ;; Wrap each query in an asynchronous call, with it's VAR as
+       ;; Wrap each query in an asynchronous call, with its VAR as
        ;; callback argument, so the PUSH-FN can put it in the alist
        ;; RESULTS.
        ,@(mapcar (lambda (form)
@@ -1072,7 +1072,7 @@ See the glib documentation at url
   "Search for a PCRE on PAGES of docüment FILE-OR-BUFFER.
 
 See `pdf-info-normalize-page-range' for valid PAGES formats and
-`pdf-info-search-string' for it's return value.
+`pdf-info-search-string' for its return value.
 
 Uses the flags in `pdf-info-regexp-flags', which see.  If
 `case-fold-search' is non-nil, the caseless flag is added.
@@ -1129,7 +1129,7 @@ TYPE may be one of
 
 goto-dest -- This is a internal link to some page.  Each element
 contains additional keys PAGE and TOP, where PAGE is the page of
-the link and TOP it's vertical position.
+the link and TOP its vertical position.
 
 goto-remote -- This a external link to some document.  Same as
 goto-dest, with an additional FILENAME of the external PDF.
@@ -1288,12 +1288,12 @@ This function returns the annotations for PAGES as a list of
 alists.  Each element of this list describes one annotation and
 contains the following keys.
 
-page     - It's page number. 
-edges    - It's area.
+page     - Its page number. 
+edges    - Its area.
 type     - A symbol describing the annotation's type.
 id       - A document-wide unique symbol referencing this annotation.
-flags    - It's flags, binary encoded.
-color    - It's color in standard Emacs notation.
+flags    - Its flags, binary encoded.
+color    - Its color in standard Emacs notation.
 contents - The text of this annotation.
 modified - The last modification date of this annotation.
 

--- a/lisp/pdf-isearch.el
+++ b/lisp/pdf-isearch.el
@@ -119,7 +119,7 @@ searching across multiple lines.")
     kmap)
   "Keymap used in `pdf-isearch-active-mode'.
 
-This keymap is used, when isearching in PDF buffers.  It's parent
+This keymap is used, when isearching in PDF buffers.  Its parent
 keymap is `isearch-mode-map'.")
 
 (put 'image-scroll-up 'isearch-scroll t)

--- a/lisp/pdf-links.el
+++ b/lisp/pdf-links.el
@@ -178,7 +178,7 @@ links via \\[pdf-links-isearch-link].
 
 ;;;###autoload
 (defun pdf-links-action-perform (link)
-  "Follow LINK, depending on it's type.
+  "Follow LINK, depending on its type.
 
 This may turn to another page, switch to another PDF buffer or
 invoke `pdf-links-browse-uri-function'.

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -611,7 +611,7 @@ at the top edge of the page moves to the previous page."
 (defun pdf-view-goto-label (label)
   "Goto the page corresponding to LABEL.
 
-Usually the label of a document's page is the same as it's
+Usually the label of a document's page is the same as its
 displayed page number."
   (interactive
    (list (let ((labels (pdf-info-pagelabels)))
@@ -886,7 +886,7 @@ If WINDOW is t, redisplay pages in all windows."
       (overlay-put ol 'pdf-view t))
     (overlay-put ol 'window (car winprops))
     (unless (windowp (car winprops))
-      ;; It's a pseudo entry.  Let's make sure it's not displayed (the
+      ;; Its a pseudo entry.  Let's make sure its not displayed (the
       ;; `window' property is only effective if its value is a window).
       (cl-assert (eq t (car winprops)))
       (delete-overlay ol))

--- a/lisp/pdf-virtual.el
+++ b/lisp/pdf-virtual.el
@@ -498,7 +498,7 @@ PAGE should be a page-number."
 (advice-add 'pdf-virtual-view-mode
             :around 'pdf-virtual-view-mode-prepare)
 
-;; This needs to run before pdf-view-mode does it's thing.
+;; This needs to run before pdf-view-mode does its thing.
 (defun pdf-virtual-view-mode-prepare (fn)
   (let (list unreadable)
     (save-excursion

--- a/lisp/tablist.el
+++ b/lisp/tablist.el
@@ -255,7 +255,7 @@ column.
 
 The function is called with 4 further arguments: ID, INDEX,
 STRING and POS, where ID represents an entry, INDEX is the index
-of the column to complete, STRING it's current value and POS an
+of the column to complete, STRING its current value and POS an
 offset of the current position of point into STRING.
 
 The function should return a collection for this column, suitable
@@ -1825,7 +1825,7 @@ Named filter are saved in the variable `tablist-named-filter'."
 (defun tablist-display-filter (&optional flag)
   "Display the current filter according to FLAG.
 
-If FLAG has the value 'toggle, toggle it's visibility.
+If FLAG has the value 'toggle, toggle its visibility.
 If FLAG has the 'state, then do nothing but return the current 
 visibility."
   (interactive (list 'toggle))


### PR DESCRIPTION
replaced minor grammar error across lisp function docstrings. 