### PR TITLE
Make pdf-view-scale-reset use the default zoom.

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -444,7 +444,7 @@ a local copy of a remote file."
 
 (defun pdf-view-scale-reset ()
   (interactive)
-  (setq pdf-view-display-size 1.0)
+  (setq pdf-view-display-size (default-value 'pdf-view-display-size))
   (pdf-view-redisplay t))
 
 


### PR DESCRIPTION
With this edit to line 447 of pdf-view.el, the function pdf-view-scale-reset will reset the zoom to default value of pdf-view-display-size instead of to a hardcoded 1.0. This will tell the pdf to scale to whatever pdf-view-display-size has been customized to when the user presses the '0' key, or to fit-width otherwise.

1.0 is miniscule for for me on my high-dpi display, and I'd much rather have it go to the default value of fit-width. This is also the behavior that users expect; if they set a default for pdf-view-display-size, they expect that to correspond to both the scale the viewer loads to and the scale you get by resetting with the '0' key.
