### PR TITLE
Automate the build on FreeBSD

### DIFF
--- a/README.org
+++ b/README.org
@@ -129,8 +129,8 @@
   $ pkg install autotools gmake poppler-glib
 #+END_SRC
 
-     If you choose not to install from MELPA, you must substitute
-    `gmake` for `make` in the build instructions below.
+     If you choose not to install from melpa, you must substitute
+    ~gmake~ for ~make~ in the instructions below.
 *** Compilation
     Now it's time to compile the source.      
 #+begin_src sh

--- a/README.org
+++ b/README.org
@@ -122,6 +122,15 @@
      or likewise within Emacs using `setenv`.
      
      After that, compilation should proceed as normal.
+**** Compiling on FreeBSD
+     Although not officially suppported, it has been reported that
+     pdf-tools work well on FreeBSD.  Install the dependencies with
+#+BEGIN_SRC sh
+  $ pkg install autotools gmake poppler-glib
+#+END_SRC
+
+     If you choose not to install from MELPA, you must substitute
+    `gmake` for `make` in the build instructions below.
 *** Compilation
     Now it's time to compile the source.      
 #+begin_src sh

--- a/lisp/pdf-tools.el
+++ b/lisp/pdf-tools.el
@@ -259,8 +259,11 @@ CALLBACK may be a function, which will be locally put on
 `compilation-finish-functions', which see."
   (if (file-executable-p pdf-info-epdfinfo-program)
       (message "%s" "Server already build.")
-    (unless (executable-find "make")
-      (error "Executable `make' command not found"))
+    (if (eq system-type 'berkeley-unix)
+        (unless (executable-find "gmake")
+          (error "Executable `gmake' command not found"))
+      (unless (executable-find "make")
+        (error "Executable `make' command not found")))
     (unless build-directory
       (setq build-directory
             (expand-file-name
@@ -281,9 +284,14 @@ CALLBACK may be a function, which will be locally put on
            (compilation-buffer-name-function
             (lambda (&rest _)
               (setq compilation-buffer
-                    (generate-new-buffer-name "*compile pdf-tools*")))))
+                    (generate-new-buffer-name "*compile pdf-tools*"))))
+           (make-cmd
+            (if (eq system-type 'berkeley-unix)
+                "gmake"
+              "make")))
       (compile 
-       (format "make V=0 -kC '%s' %smelpa-build"
+       (format "%s V=0 -kC '%s' %smelpa-build"
+               make-cmd
                build-directory
                (if install-server-deps "install-server-deps " " "))
        install-server-deps)


### PR DESCRIPTION
The GNU make binary on FreeBSD (and other BSDs) is named `gmake`.  This
change makes the build work for those systems.  It's been tested on
FreeBSD, but should work on other BSDs.  A short note was also added in
README.org to help FreeBSD users get things working.