### PR TITLE
Removed duplicate :type in pdf-misc-programm-args

### DIFF
--- a/lisp/pdf-misc.el
+++ b/lisp/pdf-misc.el
@@ -244,7 +244,6 @@ It is called with one argument, the PDF file."
 (defcustom pdf-misc-print-programm-args nil
   "List of additional arguments passed to `pdf-misc-print-programm'."
   :group 'pdf-misc
-  :type 'file
   :type '(repeat string))
 
 (defun pdf-misc-print-programm (&optional interactive-p)


### PR DESCRIPTION
The defcustom form had two types. I removed the incorrect one, i.e.,
:type 'file,  and left :type '(repeat string).