### PR TITLE
Enable building under Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,8 @@ install-server-deps:
 melpa-build: server/epdfinfo
 	-cp -p server/epdfinfo ..
 	@if [ "$(shell uname -o)" = "Msys" ]; then \
-		for f in $(shell ldd server/epdfinfo | awk '/mingw/ {print $$1}'); do \
-			cp /$(MSYSTEM)/bin/$$f ..; \
+		for f in $(shell ldd server/epdfinfo | awk '/mingw/ {print $$3}'); do \
+			cp $$f ..; \
 		done; \
 	fi
 	$(MAKE) distclean

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,11 @@ install-server-deps:
 
 melpa-build: server/epdfinfo
 	-cp -p server/epdfinfo ..
+	@if [ "$(shell uname -o)" = "Msys" ]; then \
+		for f in $(shell ldd server/epdfinfo | awk '/mingw/ {print $$1}'); do \
+			cp /$(MSYSTEM)/bin/$$f ..; \
+		done; \
+	fi
 	$(MAKE) distclean
 	@if [ -x ../epdfinfo ]; then \
 		echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"; \

--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -62,7 +62,9 @@
   :group 'pdf-tools)
   
 (defcustom pdf-info-epdfinfo-program
-  (expand-file-name "epdfinfo"
+  (expand-file-name (if (eq system-type 'windows-nt)
+			"epdfinfo.exe"
+		      "epdfinfo")
                     (file-name-directory
                      (or load-file-name default-directory)))
   "Filename of the epdfinfo executable."

--- a/server/configure.ac
+++ b/server/configure.ac
@@ -54,7 +54,7 @@ if test "$HAVE_POPPLER_ANNOT_MARKUP" = yes; then
 fi
 
 # Checks for header files.
-AC_CHECK_HEADERS([stdlib.h string.h strings.h])
+AC_CHECK_HEADERS([stdlib.h string.h strings.h err.h])
 
 AC_MSG_CHECKING([for error.h])
 SAVED_CFLAGS=$CFLAGS
@@ -76,7 +76,7 @@ AC_C_BIGENDIAN
 # Checks for library functions.
 AC_FUNC_ERROR_AT_LINE
 AC_FUNC_STRTOD
-AC_CHECK_FUNCS([strcspn strtol])
+AC_CHECK_FUNCS([strcspn strtol getline])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
This is a quite simple patch for building the server on Windows. I just added some missing functions and switched stdin/stdout to binary mode to avoid line ending issues. It has been tested using MSYS2.

The executable and the necessary dll's must be copied manually and pdf-info-epdfinfo-program needs to be set to include the ".exe" suffix.