### PR TITLE
Add Automake to brew install command for OSX

### DIFF
--- a/README.org
+++ b/README.org
@@ -111,7 +111,7 @@
      to have been successfully compiled.  You will need to install
      poppler which you can get with homebrew via
 #+BEGIN_SRC sh
-  $ brew install poppler
+  $ brew install poppler automake
 #+END_SRC
 
      You will also have to help ~pkg-config~ find some libraries by


### PR DESCRIPTION
Both automake and poppler are required for use on OSX and both are able to be installed with brew.

When I tried installing on OSX after installing poppler I got the following error `autoreconf: command not found`.

Installing automake via brew fixed the error and appears to have lead to a working installation on OSX.