### PR TITLE
Use user-error instead of error in pdf-view-goto-page

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -491,7 +491,7 @@ a local copy of a remote file."
            (read-number "Page: "))))
   (unless (and (>= page 1)
                (<= page (pdf-cache-number-of-pages)))
-    (error "No such page: %d" page))
+    (user-error "No such page: %d" page))
   (unless window
     (setq window
           (if (pdf-util-pdf-window-p)


### PR DESCRIPTION
This prevents a backtrace buffer from popping up when trying to scroll past the
end of the document.

This seems common enough and annoying enough to warrant using a less intrusive error.