### PR TITLE
Allow page-up, page-down to turn by the size of the window

### DIFF
--- a/TODO
+++ b/TODO
@@ -21,6 +21,7 @@
    pdf-view-display-image), which is actually not so desirable, since
    it is absolute.  This results e.g. in the image popping out of the
    window, when it is shrunken.
+** [Trung] Toggle hide/show cursor 
 * pdf-info
 ** Add a report/debug command, displaying a list of open files and other information.
 ** Use alists for results instead of positional lists.

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -19,9 +19,9 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;; 
+;;
 ;;; Code:
-;; 
+;;
 
 (require 'image-mode)
 (require 'pdf-util)
@@ -58,7 +58,7 @@ other value behaves like `fit-width'."
   "Fractional amount of resizing of one resize command."
   :group 'pdf-view
   :type 'number)
-  
+
 (defcustom pdf-view-continuous t
   "In Continuous mode reaching the page edge advances to next/previous page.
 
@@ -153,7 +153,7 @@ used."
 
 See :relief property in Info node `(elisp) Image Descriptors'."
   :group 'pdf-view
-  :type '(integer :tag "Pixel")         
+  :type '(integer :tag "Pixel")
   :link '(info-link "(elisp) Image Descriptors"))
 
 (defcustom pdf-view-max-image-width 4800
@@ -267,7 +267,7 @@ regarding display of the region in the later function.")
     (define-key map (kbd "C-c C-d") 'pdf-view-dark-minor-mode)
     (define-key map (kbd "m") 'pdf-view-position-to-register)
     (define-key map (kbd "'") 'pdf-view-jump-to-register)
-    
+
     (define-key map (kbd "C-c C-i") 'pdf-view-extract-region-image)
     ;; Rendering
     (define-key map (kbd "C-c C-r m") 'pdf-view-midnight-minor-mode)
@@ -288,7 +288,7 @@ PNG images in Emacs buffers."
                  (let ((file-name-handler-alist nil))
                    (not (and buffer-file-name
                              (file-readable-p buffer-file-name)))))
-             (pdf-tools-pdf-buffer-p))             
+             (pdf-tools-pdf-buffer-p))
     (let ((tempfile (pdf-util-make-temp-file
                      (concat (if buffer-file-name
                                  (file-name-nondirectory
@@ -345,7 +345,7 @@ PNG images in Emacs buffers."
   (add-hook 'kill-buffer-hook 'pdf-view-close-document nil t)
   (pdf-view-add-hotspot-function
    'pdf-view-text-regions-hotspots-function -9)
-  
+
   ;; Keep track of display info
   (add-hook 'image-mode-new-window-functions
             'pdf-view-new-window-function nil t)
@@ -533,9 +533,15 @@ a local copy of a remote file."
     (user-error "Last page"))
   (when (< (+ (pdf-view-current-page) n) 1)
     (user-error "First page"))
-  (let ((pdf-view-inhibit-redisplay t))
-    (pdf-view-goto-page
-     (+ (pdf-view-current-page) n)))
+  ;; alow page-up, page-down to turn by a page of window-size
+  (let* ((pdf-view-inhibit-redisplay t)
+         (wdn-height (window-height (selected-window)))
+         (lines-to-move (cond ((> n 0) (- wdn-height 4))
+                              ((< n 0) (- 4 wdn-height))
+                              (t 0))))
+    (when (= (window-vscroll) (image-next-line lines-to-move))
+      (pdf-view-goto-page (+ (pdf-view-current-page) n))
+      (if (> n 0) (image-bob) (image-eob))))
   (force-mode-line-update)
   (sit-for 0)
   (when pdf-view--next-page-timer
@@ -650,7 +656,7 @@ displayed page number."
   (let ((index (cl-position label (pdf-info-pagelabels) :test 'equal)))
     (unless index
       (error "No such label: %s" label))
-    (pdf-view-goto-page (1+ index))))  
+    (pdf-view-goto-page (1+ index))))
 
 
 ;; * ================================================================== *
@@ -792,7 +798,7 @@ See also `pdf-view-use-imagemagick'."
                   (* 2 (car size)))))
          (hotspots (pdf-view-apply-hotspot-functions
                     window page size)))
-    (pdf-view-create-image data 
+    (pdf-view-create-image data
       :width (car size)
       :map hotspots
       :pointer 'arrow)))
@@ -1006,7 +1012,7 @@ This tells the various modes to use their face's dark colors."
       (remove-hook 'after-save-hook enable t)
       (remove-hook 'after-revert-hook enable t))))
   (pdf-info-setoptions :render/printed pdf-view-printer-minor-mode)
-  (pdf-cache-clear-images) 
+  (pdf-cache-clear-images)
   (pdf-view-redisplay t))
 
 (define-minor-mode pdf-view-midnight-minor-mode
@@ -1094,7 +1100,7 @@ supercede hotspots in lower ones."
   "Return the active region, a list of edges.
 
 Deactivate the region if DEACTIVATE-P is non-nil."
-  
+
   (pdf-view-assert-active-region)
   (prog1
       pdf-view-active-region
@@ -1229,7 +1235,7 @@ This is more useful for commands like
            (pdf-info-renderpage-text-regions
             page width nil nil
             `(,(car colors) ,(cdr colors) ,@region)))))))
-    
+
 (defun pdf-view-kill-ring-save ()
   "Copy the region to the `kill-ring'."
   (interactive)
@@ -1308,7 +1314,7 @@ the `convert' programm is used. "
                          "-gravity" "Center"
                          "-append"
                          "+gravity"
-                         "-chop" "0x10+0+0")                         
+                         "-chop" "0x10+0+0")
              :apply '((0 0 0 0))))
           (with-current-buffer output-buffer
             (let ((inhibit-read-only t))
@@ -1401,7 +1407,7 @@ works only with bookmarks created by
     (let (bookmark-after-jump-hook)
       (pdf-view-bookmark-jump-handler bmk)
       (run-hooks 'bookmark-after-jump-hook))))
-    
+
 (defun pdf-view-registerv-make ()
   "Create a PDF register entry of the current position."
   (registerv-make
@@ -1445,7 +1451,7 @@ This macro may not work as desired when it is nested.  See also
            (progn ,@body)
          (when ,dedicated-p
            (setq pdf-view-register-alist register-alist))))))
-    
+
 (defun pdf-view-position-to-register (register)
   "Store current PDF position in register REGISTER.
 
@@ -1460,7 +1466,7 @@ See also `point-to-register'."
   "Move point to a position stored in a REGISTER."
   (interactive
    (pdf-view-with-register-alist
-     (list 
+     (list
       (register-read-with-preview "Jump to register: ")
       current-prefix-arg
       (and (or pdf-view-use-dedicated-register


### PR DESCRIPTION
Hi,

When using your package, I found out that page-up, page-down always turn the entire page.
For example, if the screen currently displays the top position of the page, then page-up, page-down will turn to the top position of the next or previous page.

This is not really convenient for me when working in small screens like in laptops. Therefore, I modify your tool a bit to make them turn an amount equivalent to the height of the current window.
If the remaining of the page is less than the window height, then the page will be moved to the bottom or the top position.

Do you think that this feature is useful?
I'd like to create a PR here, in the case it may be helpful.

Thanks!

