### PR TITLE
Support Git clone installation (closes #287)

### DIFF
--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -49,7 +49,6 @@
 ;;; Code:
 
 (require 'tq)
-(require 'cl)
 (require 'cl-lib)
 
 
@@ -65,7 +64,7 @@
 (defcustom pdf-info-epdfinfo-program
   (expand-file-name (if (eq system-type 'windows-nt) "epdfinfo.exe" "epdfinfo")
                     (let ((dir (file-name-directory (or load-file-name default-directory))))
-                      (find-if 'file-exists-p
+                      (cl-find-if 'file-exists-p
                                `(,(expand-file-name "build" dir)
                                  ,(expand-file-name "../server" dir)
                                  dir)

--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -66,8 +66,7 @@
                     (let ((dir (file-name-directory (or load-file-name default-directory))))
                       (cl-find-if 'file-exists-p
                                `(,(expand-file-name "build" dir)
-                                 ,(expand-file-name "../server" dir)
-                                 dir)
+                                 ,(expand-file-name "../server" dir))
                                )))
   "Filename of the epdfinfo executable."
   :group 'pdf-info

--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -49,6 +49,7 @@
 ;;; Code:
 
 (require 'tq)
+(require 'cl)
 (require 'cl-lib)
 
 

--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -62,11 +62,13 @@
   :group 'pdf-tools)
 
 (defcustom pdf-info-epdfinfo-program
-  (expand-file-name (if (eq system-type 'windows-nt)
-			"epdfinfo.exe"
-		      "epdfinfo")
-                    (file-name-directory
-                     (or load-file-name default-directory)))
+  (expand-file-name (if (eq system-type 'windows-nt) "epdfinfo.exe" "epdfinfo")
+                    (let ((dir (file-name-directory (or load-file-name default-directory))))
+                      (find-if 'file-exists-p
+                               `(,(expand-file-name "build" dir)
+                                 ,(expand-file-name "../server" dir)
+                                 dir)
+                               )))
   "Filename of the epdfinfo executable."
   :group 'pdf-info
   :type '(file :must-match t))

--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -65,9 +65,8 @@
   (expand-file-name (if (eq system-type 'windows-nt) "epdfinfo.exe" "epdfinfo")
                     (let ((dir (file-name-directory (or load-file-name default-directory))))
                       (cl-find-if 'file-exists-p
-                               `(,(expand-file-name "build" dir)
-                                 ,(expand-file-name "../server" dir))
-                               )))
+                                  `(,(expand-file-name "../server" dir)
+                                    ,dir))))
   "Filename of the epdfinfo executable."
   :group 'pdf-info
   :type '(file :must-match t))


### PR DESCRIPTION
Let the default value of `pdf-info-epdfinfo-program` automatically
determine if PDF Tools is installed as a Melpa package (where the
epdfinfo binary is in ./build) or as a Git clone (where it's found at
../server/)