### PR TITLE
Makefile(install-server-deps): add multi-distro support with auto-detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ PKGFILE_CONTENT = (define-package "pdf-tools" "$(PACKAGE_VERSION)"	\
 PACKAGE_NAME = pdf-tools-$(PACKAGE_VERSION)
 PACKAGE_DIR = $(PACKAGE_NAME)
 
+PACKAGE_MANAGER_APT_GET := $(shell which apt-get 2>/dev/null)
+PACKAGE_MANAGER_EMERGE := $(shell which emerge 2>/dev/null)
+
 .PHONY: all clean distclean package bytecompile test check melpa cask-install
 
 all: package
@@ -80,11 +83,27 @@ check: bytecompile test
 print-version:
 	@[ -n '$(PACKAGE_VERSION)' ] && echo '$(PACKAGE_VERSION)'
 
-install-server-deps:
+install-server-deps-apt-get:
 	sudo apt-get install gcc g++ make automake autoconf \
 		libpng-dev libz-dev libpoppler-glib-dev
 	-sudo apt-get install libpoppler-private-dev
 	-sudo apt-get install gtklp
+
+install-server-deps-emerge:
+	sudo emerge --noreplace sys-devel/gcc sys-devel/make sys-devel/autoconf \
+	    sys-devel/automake media-libs/libpng sys-libs/zlib app-text/poppler
+	-sudo emerge --noreplace net-print/gtklp
+
+install-server-deps-unknown:
+	@echo "Installation of server dependencies failed: Cannot detect distribution"; false
+
+ifneq ($(strip $(PACKAGE_MANAGER_APT_GET)),)
+install-server-deps: install-server-deps-apt-get
+else ifneq ($(strip $(PACKAGE_MANAGER_EMERGE)),)
+install-server-deps: install-server-deps-emerge
+else
+install-server-deps: install-server-deps-unknown
+endif
 
 melpa-build: server/epdfinfo
 	-cp -p server/epdfinfo ..


### PR DESCRIPTION
This adds dependency installation on Gentoo and provides a clear mechanism to extend this support for futher distributions.