### PR TITLE
 increase discoverability of auto-trim margins minor mode 

### DIFF
--- a/README.org
+++ b/README.org
@@ -346,6 +346,7 @@
 | Fit Height / Fit Width / Fit Page        | ~H~ / ~W~ / ~P~ |
 | Trim margins (set slice to bounding box) | ~s b~           |
 | Reset margins                            | ~s r~           |
+| Toggle auto-trim mode                    | ~t~             |
 | Reset Zoom                               | 0               |
 
 | Annotations                   |                                                 |

--- a/README.org
+++ b/README.org
@@ -346,7 +346,7 @@
 | Fit Height / Fit Width / Fit Page        | ~H~ / ~W~ / ~P~ |
 | Trim margins (set slice to bounding box) | ~s b~           |
 | Reset margins                            | ~s r~           |
-| Toggle auto-trim mode                    | ~t~             |
+| Toggle auto-trim margins mode            | ~s a~           |
 | Reset Zoom                               | 0               |
 
 | Annotations                   |                                                 |

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -286,6 +286,7 @@ regarding display of the region in the later function.")
     (define-key map (kbd "s m")       'pdf-view-set-slice-using-mouse)
     (define-key map (kbd "s b")       'pdf-view-set-slice-from-bounding-box)
     (define-key map (kbd "s r")       'pdf-view-reset-slice)
+    (define-key map (kbd "s a")	      'pdf-view-auto-slice-minor-mode) 
     ;; Reconvert
     (define-key map (kbd "C-c C-c")   'doc-view-mode)
     (define-key map (kbd "g")         'revert-buffer)
@@ -849,6 +850,8 @@ See also `pdf-view-set-slice-from-bounding-box'."
    (t
     (remove-hook 'pdf-view-change-page-hook
                  'pdf-view-set-slice-from-bounding-box t))))
+
+
 
 
 ;; * ================================================================== *


### PR DESCRIPTION
added shortcut key to toggle auto-trim-margins mode (i.e. `pdf-view-auto-slice-minor-mode`), and modified README accordingly. this is an incredibly useful feature for certain scanned documents and seems worth highlighting more prominently. (I ended up re-implementing it at first because the better-documented `s b` is not terribly useful for scanned documents because it needs resetting each page. Later I came across `pdf-view-auto-slice-minor-mode` and realised that I'd just re-implemented its functionality.)