### PR TITLE
Check for NixOS after macOS

### DIFF
--- a/server/autobuild
+++ b/server/autobuild
@@ -384,8 +384,8 @@ os_gentoo() {
 
 handle_options "$@"
 
-os_nixos   "$@" || \
 os_macos   "$@" || \
+os_nixos   "$@" || \
 os_freebsd "$@" || \
 os_arch    "$@"	|| \
 os_centos  "$@"	|| \


### PR DESCRIPTION
On Darwin at least, if `nix` is installed then `autobuild` will fail as it tries
to pull NixOS dependencies. Changing the order of the OS check is sufficient to
fix this, though a more robust check for NixOS may be in order, since `nix` can
be installed on any Unix-like (even Windows subsytems).