### PR TITLE
Use clang when building the server with nix-shell

### DIFF
--- a/server/autobuild
+++ b/server/autobuild
@@ -357,7 +357,7 @@ os_nixos() {
     command="$command;export AUTOBUILD_NIX_SHELL"
     command="$command;$(quote "$0" "$@")"
     exec nix-shell --pure --command "$command" \
-         -p gcc gnumake automake autoconf pkgconfig libpng zlib poppler
+         -p clang gnumake automake autoconf pkgconfig libpng zlib poppler
 }
 
 # Gentoo

--- a/server/autobuild
+++ b/server/autobuild
@@ -356,7 +356,7 @@ os_nixos() {
     command="AUTOBUILD_NIX_SHELL=true"
     command="$command;export AUTOBUILD_NIX_SHELL"
     command="$command;$(quote "$0" "$@")"
-    exec nix-shell --pure --command "$command" \
+    exec nix-shell --pure --run "$command" \
          -p clang gnumake automake autoconf pkgconfig libpng zlib poppler
 }
 


### PR DESCRIPTION
Hi:
Thanks for your work on pdf-tools. Recently tried to build the server in darwin with nix, but does not compile correctly with gcc, reading the issues on nixpkgs seems that gcc still not fully functional on darwin. Thanks in advance

Relevant `config.log` when building on darwin with gcc:
<details>

```
...
configure:3399: checking for C compiler version
configure:3408: gcc --version >&5
gcc (GCC) 6.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

configure:3419: $? = 0
configure:3408: gcc -v >&5
Using built-in specs.
COLLECT_GCC=/nix/store/9yhr8kllclz6zgvh69asld1axkqjgg89-gcc-6.4.0/bin/gcc
COLLECT_LTO_WRAPPER=/nix/store/9yhr8kllclz6zgvh69asld1axkqjgg89-gcc-6.4.0/libexec/gcc/x86_64-apple-darwin/6.4.0/lto-wrapper
Target: x86_64-apple-darwin
Configured with: 
Thread model: posix
gcc version 6.4.0 (GCC) 
configure:3419: $? = 0
configure:3408: gcc -V >&5
gcc: error: unrecognized command line option '-V'
gcc: fatal error: no input files
compilation terminated.
configure:3419: $? = 1
configure:3408: gcc -qversion >&5
gcc: error: unrecognized command line option '-qversion'; did you mean '--version'?
gcc: fatal error: no input files
compilation terminated.
configure:3419: $? = 1
configure:3439: checking whether the C compiler works
configure:3461: gcc    conftest.c  >&5
/nix/store/mhfm3v128k19gy08wr8pyp4hwsmwgc81-gcc-wrapper-6.4.0/bin/as: assembler (clang) not installed
configure:3465: $? = 1
configure:3503: result: no
configure: failed program was:
| /* confdefs.h */
| #define PACKAGE_NAME "epdfinfo"
| #define PACKAGE_TARNAME "epdfinfo"
| #define PACKAGE_VERSION "0.90"
| #define PACKAGE_STRING "epdfinfo 0.90"
| #define PACKAGE_BUGREPORT "politza@fh-trier.de"
| #define PACKAGE_URL ""
| #define PACKAGE "epdfinfo"
| #define VERSION "0.90"
| /* end confdefs.h.  */
| 
| int
| main ()
| {
| 
|   ;
|   return 0;
| }
configure:3508: error: in `/Users/marsam/code/pdf-tools/server':
configure:3510: error: C compiler cannot create executables
See `config.log' for more details
... 
```
</details>
