### PR TITLE
Add Appvyeor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+version: 1.0.{build}
+
+environment:
+  matrix:
+  - COMPILER: msys2
+    PLATFORM: x64
+    MSYS2_ARCH: x86_64
+    MSYS2_DIR: msys64
+    MSYSTEM: MINGW64
+    BIT: 64
+
+install:
+  # running under CI
+  - '%APPVEYOR_BUILD_FOLDER%\ci\appveyor\install.bat'
+  - 'echo End intall at: & time /t'
+
+build_script:
+  - 'pushd %APPVEYOR_BUILD_FOLDER%'
+  - 'make -f %APPVEYOR_BUILD_FOLDER%\Makefile'
+
+after_build:
+  - '%APPVEYOR_BUILD_FOLDER%\ci\appveyor\pack.bat'
+
+artifacts:
+  - path: '*.zip'
+  - path: '*.tar'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
 
 build_script:
   - 'pushd %APPVEYOR_BUILD_FOLDER%'
-  - 'make -f %APPVEYOR_BUILD_FOLDER%\Makefile'
+  - 'make autobuild -f %APPVEYOR_BUILD_FOLDER%\Makefile'
 
 after_build:
   - '%APPVEYOR_BUILD_FOLDER%\ci\appveyor\pack.bat'

--- a/ci/appveyor/install.bat
+++ b/ci/appveyor/install.bat
@@ -1,0 +1,30 @@
+@echo off
+
+cd %APPVEYOR_BUILD_FOLDER%
+
+echo Compiler: %COMPILER%
+echo Architecture: %MSYS2_ARCH%
+echo Platform: %PLATFORM%
+echo MSYS2 directory: %MSYS2_DIR%
+echo MSYS2 system: %MSYSTEM%
+echo Bits: %BIT%
+
+REM Create a writeable TMPDIR
+mkdir %APPVEYOR_BUILD_FOLDER%\tmp
+set TMPDIR=%APPVEYOR_BUILD_FOLDER%\tmp
+
+IF %COMPILER%==msys2 (
+  @echo on
+  SET "PATH=C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;C:\%MSYS2_DIR%\home\appveyor\.cask\bin;%PATH%"
+
+  bash -lc "pacman -S --needed --noconfirm git"
+
+  REM dependencies
+  bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-zlib mingw-w64-x86_64-libpng mingw-w64-x86_64-poppler mingw-w64-x86_64-imagemagick openssl mingw-w64-x86_64-openssl"
+
+  REM Set up emacs
+  bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-emacs"
+
+  REM Set up Cask
+  bash -lc "curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python"
+)

--- a/ci/appveyor/pack.bat
+++ b/ci/appveyor/pack.bat
@@ -1,0 +1,18 @@
+@echo off
+
+cd %APPVEYOR_BUILD_FOLDER%
+
+REM Create a writeable TMPDIR
+mkdir %APPVEYOR_BUILD_FOLDER%\pack
+set PACKDIR=%APPVEYOR_BUILD_FOLDER%\pack
+
+IF %COMPILER%==msys2 (
+  @echo on
+  SET "PATH=C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;C:\%MSYS2_DIR%\home\appveyor\.cask\bin;%PATH%"
+
+  REM Copy epdfinfo.exe and all dependencies
+  bash -lc "pushd /c/projects/pdf-tools; ldd server/epdfinfo.exe | grep mingw | cut -d' ' -f 3 | xargs -I {} cp {} ./pack/; cp server/epdfinfo.exe ./pack/; cp /mingw64/bin/*eay32.dll ./pack/"
+
+  REM Package epdfinfo.exe and all dependencies
+  7z a epdfinfo.zip %PACKDIR%\*.*
+)


### PR DESCRIPTION
This enables appveyor build. An successful build uploads `epdfinfo.zip` artifact which includes `epdfinfo.exe` and its dependencies.
Example: https://ci.appveyor.com/project/jeremymeng/pdf-tools/build/artifacts