### PR TITLE
Fixing Windows Compile Issue

### DIFF
--- a/README.org
+++ b/README.org
@@ -156,20 +156,10 @@
      emacs. This includes the standard binaries provided by the GNU
      project, those available as MSYS2 packages and numerous third-party
      binaries. It has been tested with emacs 25.1. Instructions are
-     provided under [[Compilation and installation on Windows]], below.
-**** Compiling on Cygwin
-     On [[https://www.cygwin.com/][Cygwin]] the following dependencies are needed.
-
-     - libpoppler-devel (*Lib* category)
-     - libpoppler-glib-devel (*Lib* category)
-     - libpng-devel (*Devel* category)
-     - make (*Devel* category)
-     - gcc-core (*Devel* category)
-     - gcc-g++ (*Devel* category)
-     - autoconf (*Devel* category)
-     - automake (*Devel* category)
-     - perl (*Perl* category)
-     - emacs-w32 (*Editors* category)
+     provided under [[#compilation-and-installation-on-windows][Compilation and installation on Windows]], below.
+     PDF Tools will successfully compile using Cygwin, but it will not be 
+     able to open PDFs properly due to the way binaries compiled with Cygwin
+     handle file paths.
 
 *** Compilation
     :PROPERTIES:
@@ -204,28 +194,28 @@
 
       2. Update and install dependencies, skipping any you already have
          #+BEGIN_SRC sh
-         pacman -Syu
-         pacman -S base-devel
-         pacman -S mingw-w64-x86_64-toolchain
-         pacman -S mingw-w64-x86_64-zlib
-         pacman -S mingw-w64-x86_64-libpng
-         pacman -S mingw-w64-x86_64-poppler
-         pacman -S mingw-w64-x86_64-imagemagick
+         $ pacman -Syu
+         $ pacman -S base-devel
+         $ pacman -S mingw-w64-x86_64-toolchain
+         $ pacman -S mingw-w64-x86_64-zlib
+         $ pacman -S mingw-w64-x86_64-libpng
+         $ pacman -S mingw-w64-x86_64-poppler
+         $ pacman -S mingw-w64-x86_64-imagemagick
          #+END_SRC
 
       3. Install PDF tools in Emacs, but do not try to compile the
          server. Instead, get a separate copy of the source somewhere
          else.
          #+BEGIN_SRC sh
-         git clone https://github.com/politza/pdf-tools
+         $ git clone https://github.com/politza/pdf-tools
          #+END_SRC
 
-      4. Open mingw64 shell
+      4. Open mingw64 shell (*Note:* You must use mingw64.exe and not msys2.exe)
 
       5. Compile pdf-tools
          #+BEGIN_SRC sh
-         cd pdf-tools/build
-         make -s
+         $ cd /path/to/pdf-tools
+         $ make -s
          #+END_SRC
 
       6. This should produce a file ~server/epdfinfo.exe~. Copy this file
@@ -250,7 +240,7 @@
 
  #+BEGIN_SRC emacs-lisp
  (setenv "PATH" (concat "C:\\msys64\\mingw64\\bin;" (getenv "PATH")))
-          #+END_SRC
+ #+END_SRC
 
 *** ELisp Prerequisites
     This package depends on the following Elisp packages, which should

--- a/README.org
+++ b/README.org
@@ -193,7 +193,7 @@
       1. Open msys2 shell
 
       2. Update and install dependencies, skipping any you already have
-         #+BEGIN_SRC sh
+#+BEGIN_SRC sh
          $ pacman -Syu
          $ pacman -S base-devel
          $ pacman -S mingw-w64-x86_64-toolchain
@@ -201,35 +201,35 @@
          $ pacman -S mingw-w64-x86_64-libpng
          $ pacman -S mingw-w64-x86_64-poppler
          $ pacman -S mingw-w64-x86_64-imagemagick
-         #+END_SRC
+#+END_SRC
 
       3. Install PDF tools in Emacs, but do not try to compile the
          server. Instead, get a separate copy of the source somewhere
          else.
-         #+BEGIN_SRC sh
+#+BEGIN_SRC sh
          $ git clone https://github.com/politza/pdf-tools
-         #+END_SRC
+#+END_SRC
 
       4. Open mingw64 shell (*Note:* You must use mingw64.exe and not msys2.exe)
 
       5. Compile pdf-tools
-         #+BEGIN_SRC sh
+#+BEGIN_SRC sh
          $ cd /path/to/pdf-tools
          $ make -s
-         #+END_SRC
+#+END_SRC
 
       6. This should produce a file ~server/epdfinfo.exe~. Copy this file
          into the ~pdf-tools/~ installation directory in your Emacs.
 
       7. Start Emacs and activate the package.
-         #+BEGIN_SRC
+#+BEGIN_SRC
          M-x pdf-tools-install RET
-         #+END_SRC
+#+END_SRC
 
       8. Test.
-         #+BEGIN_SRC
+#+BEGIN_SRC
          M-x pdf-info-check-epdfinfo RET
-         #+END_SRC
+#+END_SRC
 
       If this is successful, ~(pdf-tools-install)~ can be added to Emacs'
       config. Note that libraries from other GNU utilities, such as Git

--- a/lisp/pdf-tools.el
+++ b/lisp/pdf-tools.el
@@ -263,11 +263,11 @@ Returns always nil, unless `system-type' equals windows-nt."
 
 (defun pdf-tools-find-bourne-shell ()
   "Locate a usable sh."
-  (or (executable-find "sh")
-      (and (eq system-type 'windows-nt)
+  (or (and (eq system-type 'windows-nt)
            (let* ((directory (pdf-tools-msys2-directory)))
              (when directory
-               (expand-file-name "usr/bin/bash.exe" directory))))))
+               (expand-file-name "usr/bin/bash.exe" directory))))
+      (executable-find "sh")))
 
 (defun pdf-tools-build-server (target-directory
                                &optional


### PR DESCRIPTION
I ran into an error installing pdf tools using the instructions for compiling on Windows in the Readme. I was getting the "cannot find necessary poppler-private header (see README.org)" error, despite having installed mingw-w64-x86_64-poppler from my msys shell.

It turns out the problem was that my "cygwin64\bin" directory was part of my Windows path environment variable. I even had the line (setenv "PATH" (concat "<my MSYS2 install directory>\mingw64\bin;" (getenv "PATH"))) in my emacs configuration.

The reason for this issue is that "cygwin64\bin" contains a "sh.exe" file while "mingw64\bin" does not. I therefore changed the code in "pdf-tools.el" so that, if a user is running Windows, Emacs will look for Msys2 or prompt the user for their msys2 install location before looking for the sh executable. Therefore, users running Windows who have "cygwin64\bin" in their path variable won't run into any problems installing PDF tools.

I also added some information to the readme about why PDF Tools will not work if it is compiled with Cygwin. I also fixed some small issues I found with the Readme.