### PR TITLE
Make outline-regexp buffer-local in pdf-outline-buffer-mode

### DIFF
--- a/lisp/pdf-outline.el
+++ b/lisp/pdf-outline.el
@@ -166,10 +166,10 @@ additionally quit the Outline.
 rebound to their respective last character.
 
 \\{pdf-outline-buffer-mode-map}"
-  (setq outline-regexp "\\( *\\)."
-        outline-level
-        (lambda nil (1+ (/ (length (match-string 1))
-                           pdf-outline-buffer-indent))))
+  (setq-local outline-regexp "\\( *\\).")
+  (setq-local outline-level
+              (lambda nil (1+ (/ (length (match-string 1))
+                                 pdf-outline-buffer-indent))))
 
   (toggle-truncate-lines 1)
   (setq buffer-read-only t)


### PR DESCRIPTION
Changing the global value of `outline-regexp` can break other packages
(e.g. Org HTML export), so use `setq-local` when setting `outline-*`
variables in `pdf-outline-buffer-mode`.

Fixes github issue #359