### PR TITLE
Make "no such page" a user-error instead of error

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -572,7 +572,7 @@ windows."
            (read-number "Page: "))))
   (unless (and (>= page 1)
                (<= page (pdf-cache-number-of-pages)))
-    (error "No such page: %d" page))
+    (user-error "No such page: %d" page))
   (unless window
     (setq window
           (if (pdf-util-pdf-window-p)


### PR DESCRIPTION
Prevents launching debugger (if debug-on-error is non-nil).

Possibly fixes or affects #358