### PR TITLE
Revert "Fixed Indent issue with source code beginning and ending tags"

### DIFF
--- a/README.org
+++ b/README.org
@@ -202,7 +202,7 @@
       1. Open msys2 shell
 
       2. Update and install dependencies, skipping any you already have
-#+BEGIN_SRC sh
+         #+BEGIN_SRC sh
          $ pacman -Syu
          $ pacman -S base-devel
          $ pacman -S mingw-w64-x86_64-toolchain
@@ -210,35 +210,35 @@
          $ pacman -S mingw-w64-x86_64-libpng
          $ pacman -S mingw-w64-x86_64-poppler
          $ pacman -S mingw-w64-x86_64-imagemagick
-#+END_SRC
+         #+END_SRC
 
       3. Install PDF tools in Emacs, but do not try to compile the
          server. Instead, get a separate copy of the source somewhere
          else.
-#+BEGIN_SRC sh
+         #+BEGIN_SRC sh
          $ git clone https://github.com/politza/pdf-tools
-#+END_SRC
+         #+END_SRC
 
       4. Open mingw64 shell (*Note:* You must use mingw64.exe and not msys2.exe)
 
       5. Compile pdf-tools
-#+BEGIN_SRC sh
+         #+BEGIN_SRC sh
          $ cd /path/to/pdf-tools
          $ make -s
-#+END_SRC
+         #+END_SRC
 
       6. This should produce a file ~server/epdfinfo.exe~. Copy this file
          into the ~pdf-tools/~ installation directory in your Emacs.
 
       7. Start Emacs and activate the package.
-#+BEGIN_SRC
+         #+BEGIN_SRC
          M-x pdf-tools-install RET
-#+END_SRC
+         #+END_SRC
 
       8. Test.
-#+BEGIN_SRC
+         #+BEGIN_SRC
          M-x pdf-info-check-epdfinfo RET
-#+END_SRC
+         #+END_SRC
 
       If this is successful, ~(pdf-tools-install)~ can be added to Emacs'
       config. Note that libraries from other GNU utilities, such as Git


### PR DESCRIPTION
This reverts commit 1187af29a32943342141f85177bbd82de0a04e0e.

It turns out that this causes the numbering to be reverted after each source block. 

It seems standard for Readme files written in org mode not to indent the beginning of a source block embedded in a list. For example, [this one](https://github.com/github/markup/blob/master/test/markups/README.org) does indentation this way. 

The extra line that gets displayed is actually an issue with org-ruby (the library Github uses to generate markup from org mode readme files). This issue is documented [here](https://github.com/wallyqs/org-ruby/issues/31). 

Regardless, we should revert this readme back to its correct formatting. I'm sorry for suggesting a change that ended up causing more problems. I didin't realize this issue occurred until this commit had already been merged. 