### PR TITLE
Fix for bookmarks

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -1504,9 +1504,8 @@ See also `pdf-view-bookmark-make-record'."
                    (round (/ (* (cdr origin) (cdr size))
                              (frame-char-height)))))))))
     (add-hook 'bookmark-after-jump-hook show-fn-sym)
-    (switch-to-buffer
-     (or (find-buffer-visiting file)
-	 (find-file-noselect file)))))
+    (switch-to-buffer (or (find-buffer-visiting file)
+			  (find-file-noselect file)))))
 
 (defun pdf-view-bookmark-jump (bmk)
   "Switch to bookmark BMK.

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -1504,8 +1504,9 @@ See also `pdf-view-bookmark-make-record'."
                    (round (/ (* (cdr origin) (cdr size))
                              (frame-char-height)))))))))
     (add-hook 'bookmark-after-jump-hook show-fn-sym)
-    (set-buffer (or (find-buffer-visiting file)
-                    (find-file-noselect file)))))
+    (switch-to-buffer
+     (or (find-buffer-visiting file)
+	 (find-file-noselect file)))))
 
 (defun pdf-view-bookmark-jump (bmk)
   "Switch to bookmark BMK.


### PR DESCRIPTION
bookmarks wouldn't fire the hook with `set-buffer`, resulting in any bookmarks created within a pdf to break when attempting to load (at least, with bookmark+).