### PR TITLE
README.org: is this a typo?

### DIFF
--- a/README.org
+++ b/README.org
@@ -333,7 +333,7 @@
 | Jump to Occur Line                         | ~RETURN~              |
 | Pick a Link and Jump                       | ~F~                   |
 | Incremental Search in Links                | ~f~                   |
-| History Back / Forwards                    | ~B~ / ~F~             |
+| History Back / Forwards                    | ~B~ / ~N~             |
 | Display Outline                            | ~o~                   |
 | Jump to Section from Outline               | ~RETURN~              |
 | Jump to Page                               | ~M-g g~               |


### PR DESCRIPTION
It shows that

`F` is bind to `'pdf-links-action-perform`,
`N` is bind to `'pdf-history-forward`,
`B` is bind to `'pdf-history-backward`,

so maybe "History Back / Forwards" should be "B / N" instead of "B / F"?