### PR TITLE
Allow killing buffer with no associated file

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -493,7 +493,9 @@ Optional parameters IGNORE-AUTO and NOCONFIRM are defined as in
 See also `pdf-info-close', which does not return immediately."
   (when (pdf-info-running-p)
     (let ((pdf-info-asynchronous 'ignore))
-      (pdf-info-close))))
+      (with-demoted-errors
+          "Error running pdf-info-close: %S"
+          (pdf-info-close)))))
 
 
 ;; * ================================================================== *


### PR DESCRIPTION
pdf-info--normalize-file-or-buffer signals an error on no file
associated with buffer, but pdf-info-close is called when trying to
kill the buffer, making the buffer unkillable.

This change just demotes the error and handles the nil return value
from the demoted pdf-info--normalize-file-or-buffer – perhaps someone
who knows the codebase will have a better solution.