### PR TITLE
Add instructions for Alpine Linux

### DIFF
--- a/README.org
+++ b/README.org
@@ -158,6 +158,11 @@
   $ sudo dnf install make automake autoconf gcc gcc-c++ ImageMagick libpng-devel zlib-devel poppler-glib-devel
 #+END_SRC
 
+**** Compiling on Alpine Linux
+#+BEGIN_SRC sh
+  $ apk add build-base g++ gcc automake autoconf libpng-dev glib-dev poppler-dev
+#+END_SRC
+
 **** Compiling on Windows
      PDF Tools can be built and used on Windows using the MSYS2
      compiler. This will work with native (not cygwin) Windows builds of


### PR DESCRIPTION
I was trying to use my emacs environement (which contains pdf-tools) in a docker container with alpine as base image and I thought it wold be good to share with packages is required in order to compile pdf-tools.

I've tested with the folloing Dockerfile:

```Dockerfile
FROM alpine

RUN apk add build-base g++ gcc automake autoconf libpng-dev glib-dev poppler-dev && \
    wget https://github.com/politza/pdf-tools/archive/master.zip && \
    unzip master.zip && \
    ./pdf-tools-master/server/autobuild 

```