### PR TITLE
Customizable annotation list format

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -1509,6 +1509,20 @@ annotation's contents and otherwise `text-mode'. "
   :group 'pdf-annot
   :type display-buffer--action-custom-type)
 
+(defcustom pdf-annot-list-format
+  '((page . 3)
+    (type . 10)
+    (label . 24)
+    (date . 24))
+    "Annotation properties visible in the annotation list."
+  :type '(alist :key-type (symbol))
+  :options '((page (integer :value 3 :tag "Column Width"))
+	     (type (integer :value 10 :tag "Column Width" ))
+	     (label (integer :value 24 :tag "Column Width"))
+	     (date (integer :value 24 :tag "Column Width"))
+	     (comment (integer :value 56 :tag "Column Width")))
+  :group 'pdf-annot)
+
 (defvar-local pdf-annot-list-buffer nil)
 
 (defvar-local pdf-annot-list-document-buffer nil)
@@ -1555,37 +1569,57 @@ belong to the same page and A1 is displayed above/left of A2."
                                      pdf-annot-list-document-buffer)
                 'pdf-annot-compare-annotations)))
 
+(defun pdf-annot--make-entry-formatter (a)
+  (lambda (fmt)
+   (let ((entry-type (car fmt))
+	 (entry-width (cdr fmt))
+	 (prune-newlines
+	  (lambda (str)
+	    (replace-regexp-in-string "\n" " " str t t))))
+     (cl-ecase entry-type
+       (date (pdf-annot-print-property a 'modified))
+       (page (pdf-annot-print-property a 'page))
+       (label (funcall prune-newlines
+		       (pdf-annot-print-property a 'label)))
+       (comment
+	(truncate-string-to-width
+	 (funcall prune-newlines
+		(pdf-annot-print-property a 'contents))
+	 entry-width))
+       (type (pdf-annot-print-property a 'type))))))
+
 (defun pdf-annot-list-create-entry (a)
   "Create a `tabulated-list-entries' entry for annotation A."
   (list (pdf-annot-get-id a)
-        (vector
-         (pdf-annot-print-property a 'page)
-         (pdf-annot-print-property a 'type)
-         (replace-regexp-in-string
-          "\n" " "
-          (pdf-annot-print-property a 'label) t t)
-         (if (pdf-annot-get a 'modified)
-             (pdf-annot-print-property a 'modified)
-           (if (pdf-annot-get a 'created)
-               (pdf-annot-print-property a 'created)
-             "Unknown date")))))
+        (vconcat
+	 (mapcar (pdf-annot--make-entry-formatter a)
+		 pdf-annot-list-format))))
 
 (define-derived-mode pdf-annot-list-mode tablist-mode "Annots"
-  (let ((page-sorter
+  (let* ((page-sorter
          (lambda (a b)
            (< (string-to-number (aref (cadr a) 0))
-              (string-to-number (aref (cadr b) 0))))))
+              (string-to-number (aref (cadr b) 0)))))
+	 (format-generator
+	  (lambda (format)
+	   (let ((field (car format))
+		 (width (cdr format)))
+	     (cl-case field
+	       (page `("Pg." 3 ,page-sorter :read-only t :right-alight t))
+	       (t (list
+		   (capitalize (symbol-name field))
+		   width t :read-only t)))))))
     (setq tabulated-list-entries 'pdf-annot-list-entries
-          tabulated-list-format (vector
-                                 `("Pg." 3 ,page-sorter :read-only t :right-align t)
-                                 `("Type" 10 t :read-only t)
-                                 `("Label" 24 t :read-only t)
-                                 '("Date" 24 t :read-only t))
-          tabulated-list-padding 2))
+          tabulated-list-format (vconcat
+				 (mapcar
+				  format-generator
+				  pdf-annot-list-format))
+	  tabulated-list-padding 2))
   (set-keymap-parent pdf-annot-list-mode-map tablist-mode-map)
   (use-local-map pdf-annot-list-mode-map)
-  (setq tablist-current-filter
-        `(not (== "Type" "link")))
+  (when (assq 'type pdf-annot-list-format)
+    (setq tablist-current-filter
+         `(not (== "Type" "link"))))
   (tabulated-list-init-header))
 
 (defun pdf-annot-list-annotations ()

--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -1520,7 +1520,7 @@ annotation's contents and otherwise `text-mode'. "
 	     (type (integer :value 10 :tag "Column Width" ))
 	     (label (integer :value 24 :tag "Column Width"))
 	     (date (integer :value 24 :tag "Column Width"))
-	     (comment (integer :value 56 :tag "Column Width")))
+	     (contents (integer :value 56 :tag "Column Width")))
   :group 'pdf-annot)
 
 (defcustom pdf-annot-list-highlight-type t
@@ -1591,7 +1591,7 @@ belong to the same page and A1 is displayed above/left of A2."
        (page (pdf-annot-print-property a 'page))
        (label (funcall prune-newlines
 		       (pdf-annot-print-property a 'label)))
-       (comment
+       (contents
 	(truncate-string-to-width
 	 (funcall prune-newlines
 		(pdf-annot-print-property a 'contents))

--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -1523,7 +1523,7 @@ annotation's contents and otherwise `text-mode'. "
 	     (contents (integer :value 56 :tag "Column Width")))
   :group 'pdf-annot)
 
-(defcustom pdf-annot-list-highlight-type t
+(defcustom pdf-annot-list-highlight-type nil
   "Whether to highlight \"Type\" column annotation list with annotation color."
   :group 'pdf-annot
   :type 'boolean)

--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -1523,6 +1523,11 @@ annotation's contents and otherwise `text-mode'. "
 	     (comment (integer :value 56 :tag "Column Width")))
   :group 'pdf-annot)
 
+(defcustom pdf-annot-list-highlight-type t
+  "Whether to highlight \"Type\" column annotation list with annotation color."
+  :group 'pdf-annot
+  :type 'boolean)
+
 (defvar-local pdf-annot-list-buffer nil)
 
 (defvar-local pdf-annot-list-document-buffer nil)
@@ -1573,6 +1578,11 @@ belong to the same page and A1 is displayed above/left of A2."
   (lambda (fmt)
    (let ((entry-type (car fmt))
 	 (entry-width (cdr fmt))
+	 ;; Taken from css-mode.el
+	 (contrasty-color
+	  (lambda (name)
+	    (if (> (color-distance name "black") 292485)
+		"black" "white")))
 	 (prune-newlines
 	  (lambda (str)
 	    (replace-regexp-in-string "\n" " " str t t))))
@@ -1586,7 +1596,15 @@ belong to the same page and A1 is displayed above/left of A2."
 	 (funcall prune-newlines
 		(pdf-annot-print-property a 'contents))
 	 entry-width))
-       (type (pdf-annot-print-property a 'type))))))
+       (type
+	(let ((color (pdf-annot-get a 'color))
+	      (type (pdf-annot-print-property a 'type)))
+	  (if pdf-annot-list-highlight-type
+	      (propertize
+	       type 'face
+	       `(:background ,color
+		 :foreground ,(funcall contrasty-color color)))
+	    type)))))))
 
 (defun pdf-annot-list-create-entry (a)
   "Create a `tabulated-list-entries' entry for annotation A."


### PR DESCRIPTION
I sometimes have to deal with pdfs with dozens of color-coded annotations. This makes it easier by:

* Allowing customization of what columns should appear in the annotation list
* Introducing an option to highlight the type entry with the color of the annotation