### PR TITLE
Make cua-mode work with pdf-view-mode

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -32,6 +32,8 @@
 (require 'bookmark)
 (require 'password-cache)
 
+(declare-function cua-copy-region "cua-base")
+
 
 ;; * ================================================================== *
 ;; * Customizations
@@ -377,10 +379,15 @@ PNG images in Emacs buffers."
   ;; Enable transient-mark-mode, so region deactivation when quitting
   ;; will work.
   (setq-local transient-mark-mode t)
-  ;; Disable cua-mode, since it does not work with pdf-view-mode.
+  ;; In Emacs >= 24.4, `cua-copy-region' should have been advised when
+  ;; loading pdf-view.el so as to make it work with
+  ;; pdf-view-mode. Disable cua-mode if that is not the case.
   ;; FIXME: cua-mode is a global minor-mode, but setting cua-mode to
   ;; nil seems to do the trick.
-  (when (bound-and-true-p cua-mode)
+  (when (and (bound-and-true-p cua-mode)
+	     (not (and (fboundp 'advice-member-p)
+		       (advice-member-p #'cua-copy-region--pdf-view-advice
+					'cua-copy-region))))
     (setq-local cua-mode nil))
 
   (add-hook 'window-configuration-change-hook
@@ -404,6 +411,16 @@ PNG images in Emacs buffers."
 		  (current-buffer))
   ;; Setup initial page and start display
   (pdf-view-goto-page (or (pdf-view-current-page) 1)))
+
+(when (fboundp 'advice-add)
+  (defun cua-copy-region--pdf-view-advice (&rest _)
+    "If current buffer is in `pdf-view' mode, call
+`pdf-view-kill-ring-save'."
+    (when (eq major-mode 'pdf-view-mode)
+      (pdf-view-kill-ring-save)))
+  (advice-add 'cua-copy-region
+	      :before-until
+	      #'cua-copy-region--pdf-view-advice))
 
 (defun pdf-view-check-incompatible-modes (&optional buffer)
   "Check BUFFER for incompatible modes, maybe issue a warning."

--- a/test/pdf-view-test.el
+++ b/test/pdf-view-test.el
@@ -17,3 +17,12 @@
           (should (numberp (pdf-info-number-of-pages temp)))))
     (when (file-exists-p temp)
       (delete-file temp))))
+
+(ert-deftest pdf-view-cua-copy-region ()
+  (pdf-test-with-test-pdf
+   (pdf-view-mark-whole-page)
+   (should (string-match-p "PDF Tools\\(?:.\\|\n\\)*in memory"
+			   (let (kill-ring)
+			     (require 'cua-base)
+			     (cua-copy-region)
+			     (car kill-ring))))))


### PR DESCRIPTION
Commit 66dd313dbb1d078fa847805b0d7cf9797bec9e4c disables `cua-mode` in `pdf-view-mode` on the basis that the former does not work that the latter. This commits instead adds an advice to `cua-copy-region` that makes them work together. I had suggested it in issue #117. I also saw the more recent issue #419. With this commit, both `M-w` and `C-c` work correctly for me to copy the current region to the kill ring, which solves these two issues unless I missed something.