### PR TITLE
Check whether Homebrew is installed

### DIFF
--- a/server/autobuild
+++ b/server/autobuild
@@ -356,6 +356,9 @@ os_macos() {
     if ! which uname >/dev/null 2>&1 || [ "$(uname -s)" != "Darwin" ]; then
         return 1
     fi
+    if ! which brew >/dev/null 2>&1; then
+        return 1
+    fi
     PKGCMD=brew
     PKGARGS=install
     PACKAGES="pkg-config poppler automake"


### PR DESCRIPTION
`os_macos` requires homebrew installed to install the dependencies.

scenario: I use nix on darwin and I don't have homebrew installed
