### PR TITLE
 Handle edge case when getting image data from the head of the cache

### DIFF
--- a/lisp/pdf-cache.el
+++ b/lisp/pdf-cache.el
@@ -207,21 +207,16 @@ width MAX-WIDTH and `eql' hash value.
 Remember that image was recently used.
 
 Returns nil, if no matching image was found."
-  (let ((cache (cons nil pdf-cache--image-cache))
+  (let ((cache pdf-cache--image-cache)
         image)
-    ;; Find it in the cache and remove it.  We need to find the
-    ;; element in front of it.
-    (while (and (cdr cache)
+    ;; Find it in the cache.
+    (while (and (setq image (pop cache))
                 (not (pdf-cache--image-match
-                      (car (cdr cache))
-                      page min-width max-width hash)))
-      (setq cache (cdr cache)))
-    (setq image (cadr cache))
-    (when (car cache)
-      (setcdr cache (cddr cache)))
-    ;; Now push it at the front.
+                      image page min-width max-width hash))))
+    ;; Remove it and push it to the front.
     (when image
-      (push image pdf-cache--image-cache)
+      (setq pdf-cache--image-cache
+            (cons image (delq image pdf-cache--image-cache)))
       (pdf-cache--image/data image))))
 
 (defun pdf-cache-put-image (page width data &optional hash)

--- a/test/pdf-cache-test.el
+++ b/test/pdf-cache-test.el
@@ -1,0 +1,31 @@
+
+
+;; * ================================================================== *
+;; * Tests for pdf-cache.el
+;; * ================================================================== *
+
+(require 'pdf-cache)
+(require 'ert)
+
+(ert-deftest pdf-cache-get-image ()
+  (let (pdf-cache--image-cache)
+    (should-not (pdf-cache-get-image 1 1))
+    (setq pdf-cache--image-cache
+          (list
+           (pdf-cache--make-image 1 1 "1" nil)
+           (pdf-cache--make-image 2 1 "2" nil)
+           (pdf-cache--make-image 3 1 "3" nil)))
+    (should (equal (pdf-cache-get-image 1 1) "1"))
+    (should (equal pdf-cache--image-cache
+                   (list
+                    (pdf-cache--make-image 1 1 "1" nil)
+                    (pdf-cache--make-image 2 1 "2" nil)
+                    (pdf-cache--make-image 3 1 "3" nil))))
+    (should (equal (pdf-cache-get-image 2 1) "2"))
+    (should (equal pdf-cache--image-cache
+                   (list
+                    (pdf-cache--make-image 2 1 "2" nil)
+                    (pdf-cache--make-image 1 1 "1" nil)
+                    (pdf-cache--make-image 3 1 "3" nil))))
+    (should-not (pdf-cache-get-image 4 1))))
+


### PR DESCRIPTION
When examining which pages where in `pdf-cache--image-cache`  I noticed that frequently there would be duplicated pages so that the sequence of cached pages would like look `(6 6 5 4 ...)`.

The issue seemed to be with `pdf-cache-get-image` not handling the edge case where the head element of the cache is a match for the page passed as the first argument which leads to the head element being duplicated in the cache by the call to `push` in `pdf-cache-get-image`.