### PR TITLE
Support SVG and PDF rendering

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -981,6 +981,7 @@ other annotations."
                (pdf-cache-renderpage-highlight
                 page (car size)
                 `("white" "steel blue" 0.35 ,@edges))
+             :width (car size)
              :map (pdf-view-apply-hotspot-functions
                    window page size))))
         (pdf-util-scroll-to-edges

--- a/lisp/pdf-cache.el
+++ b/lisp/pdf-cache.el
@@ -104,6 +104,9 @@ is nil and VALUE undefined."
            pdf-cache--data)
   nil)
 
+(defun pdf-cache-clear-imagetype ()
+  (pdf-cache--data-clear 'imagetype))
+
 (defun pdf-cache-clear-data-of-pages (&rest pages)
   (when pdf-cache--data
     (dolist (page pages)

--- a/lisp/pdf-cache.el
+++ b/lisp/pdf-cache.el
@@ -149,6 +149,7 @@ Make sure, not to modify it's return value." command)))
 (define-pdf-cache-function boundingbox t)
 (define-pdf-cache-function textregions t)
 (define-pdf-cache-function pagesize t)
+(define-pdf-cache-function imagetype)
 
 
 ;; * ================================================================== *

--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -1000,6 +1000,9 @@ A No-op, if BUFFER has not running server instance."
 (defun pdf-info-markup-annotations-p ()
   (not (null (memq 'markup-annotations (pdf-info-features)))))
 
+(defun pdf-info-render-pdf-p ()
+  (not (null (memq 'render-pdf (pdf-info-features)))))
+
 (defmacro pdf-info-assert-writable-annotations ()
   `(unless (memq 'writable-annotations (pdf-info-features))
      (error "Writing annotations is not supported by this version of epdfinfo")))

--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -562,6 +562,7 @@ interrupted."
        (column . ,(string-to-number (cadr (cdar response))))))
     (delannot nil)
     ((save) (caar response))
+    (imagetype (intern (caar response)))
     ((renderpage renderpage-text-regions renderpage-highlight)
      (pdf-util-munch-file (caar response)))
     ((setoptions getoptions)
@@ -1689,6 +1690,14 @@ Returns a list \(LEFT TOP RIGHT BOT\)."
    'boundingbox
    (pdf-info--normalize-file-or-buffer file-or-buffer)
    page))
+
+(defun pdf-info-imagetype (&optional file-or-buffer)
+  "Return the image type of the current PDF.
+
+Returns the extension of the image type excluding the dot."
+  (pdf-info-query
+   'imagetype
+   (pdf-info--normalize-file-or-buffer file-or-buffer)))
 
 (defun pdf-info-getoptions (&optional file-or-buffer)
   (pdf-info-query

--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -1003,6 +1003,9 @@ A No-op, if BUFFER has not running server instance."
 (defun pdf-info-render-pdf-p ()
   (not (null (memq 'render-pdf (pdf-info-features)))))
 
+(defun pdf-info-render-svg-p ()
+  (not (null (memq 'render-svg (pdf-info-features)))))
+
 (defmacro pdf-info-assert-writable-annotations ()
   `(unless (memq 'writable-annotations (pdf-info-features))
      (error "Writing annotations is not supported by this version of epdfinfo")))

--- a/lisp/pdf-isearch.el
+++ b/lisp/pdf-isearch.el
@@ -742,7 +742,8 @@ MATCH-BG LAZY-FG LAZY-BG\)."
                                  occur-hack-p)
                              (eq page (pdf-view-current-page)))
                     (pdf-view-display-image
-                     (pdf-view-create-image data))))))))
+                     (pdf-view-create-image data
+                       :width width))))))))
       (pdf-info-renderpage-text-regions
        page width t nil
        `(,fg1 ,bg1 ,@(pdf-util-scale-pixel-to-relative

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -1465,7 +1465,8 @@ This is more useful for commands like
               `(,(car colors) ,(cdr colors) 0.35 ,@region))
            (pdf-info-renderpage-text-regions
             page width nil nil
-            `(,(car colors) ,(cdr colors) ,@region)))))))
+            `(,(car colors) ,(cdr colors) ,@region)))
+       :width width))))
 
 (defun pdf-view-kill-ring-save ()
   "Copy the region to the `kill-ring'."

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -1,9 +1,10 @@
 bin_PROGRAMS = epdfinfo
 epdfinfo_CFLAGS = -Wall $(glib_CFLAGS) $(poppler_glib_CFLAGS) $(poppler_CFLAGS) \
-			$(png_CFLAGS)
+			$(png_CFLAGS) $(cairo_svg_CFLAGS) $(cairo_pdf_CFLAGS)
 epdfinfo_CXXFLAGS = -Wall $(epdfinfo_CFLAGS)
 epdfinfo_LDADD =  $(glib_LIBS) $(poppler_glib_LIBS) $(poppler_LIBS) \
-			$(png_LIBS) libsynctex.a $(zlib_LIBS)
+			$(png_LIBS) libsynctex.a $(zlib_LIBS) $(cairo_svg_LIBS) \
+			$(cairo_pdf_LIBS)
 epdfinfo_SOURCES = epdfinfo.c epdfinfo.h poppler-hack.cc
 
 noinst_LIBRARIES = libsynctex.a

--- a/server/configure.ac
+++ b/server/configure.ac
@@ -18,14 +18,20 @@ AM_PROG_AR
 HAVE_POPPLER_FIND_OPTS="no   (requires poppler-glib >= 0.22)"
 HAVE_POPPLER_ANNOT_WRITE="no   (requires poppler-glib >= 0.19.4)"
 HAVE_POPPLER_ANNOT_MARKUP="no (requires poppler-glib >= 0.26)"
+HAVE_RENDER_SVG="no (requires cairo-svg >= 1.16)"
+HAVE_RENDER_PDF="no (requires cairo-pdf >= 1.2)"
 
 PKG_CHECK_MODULES([png], [libpng])
 PKG_CHECK_MODULES([glib], [glib-2.0])
 PKG_CHECK_MODULES([poppler], [poppler])
+PKG_CHECK_MODULES([cairo_pdf], [cairo-pdf])
+PKG_CHECK_MODULES([cairo_svg], [cairo-svg])
 PKG_CHECK_MODULES([poppler_glib], [poppler-glib >= 0.16.0])
 PKG_CHECK_EXISTS([poppler-glib >= 0.19.4], [HAVE_POPPLER_ANNOT_WRITE=yes])
 PKG_CHECK_EXISTS([poppler-glib >= 0.22], [HAVE_POPPLER_FIND_OPTS=yes])
 PKG_CHECK_EXISTS([poppler-glib >= 0.26], [HAVE_POPPLER_ANNOT_MARKUP=yes])
+PKG_CHECK_EXISTS([cairo-pdf >= 1.2], [HAVE_RENDER_PDF=yes])
+PKG_CHECK_EXISTS([cairo-svg >= 1.16], [HAVE_RENDER_SVG=yes])
 PKG_CHECK_MODULES([zlib], [zlib])
 
 AC_COMPILE_IFELSE(
@@ -75,6 +81,16 @@ if test "$HAVE_POPPLER_ANNOT_MARKUP" = yes; then
     [Define to 1 to enable adding of markup annotations (requires poppler-glib >= 0.26).])
 fi
 
+if test "$HAVE_RENDER_SVG" = yes; then
+  AC_DEFINE([HAVE_RENDER_SVG],1,
+    [Define to 1 to enable rendering pages as SVG (requires cairo-svg >= 1.16).])
+fi
+
+if test "$HAVE_RENDER_PDF" = yes; then
+  AC_DEFINE([HAVE_RENDER_PDF],1,
+    [Define to 1 to enable rendering pages as PDF (requires cairo-pdf >= 1.2).])
+fi
+
 AC_CANONICAL_HOST
 # Checks for header files.
 AC_CHECK_HEADERS([stdlib.h string.h strings.h err.h])
@@ -110,4 +126,6 @@ echo
 echo "Is case-sensitive searching enabled ?     ${HAVE_POPPLER_FIND_OPTS}"
 echo "Is modifying text annotations enabled ?   ${HAVE_POPPLER_ANNOT_WRITE}"
 echo "Is modifying markup annotations enabled ? ${HAVE_POPPLER_ANNOT_MARKUP}"
+echo "Can render pages as SVG ? ${HAVE_RENDER_SVG}"
+echo "Can render pages as PDF ? ${HAVE_RENDER_PDF}"
 echo

--- a/server/epdfinfo.c
+++ b/server/epdfinfo.c
@@ -27,10 +27,10 @@
 #include <glib.h>
 #include <poppler.h>
 #include <cairo.h>
-#ifdef CAIRO_HAS_PDF_SURFACE
+#ifdef HAVE_RENDER_PDF
 #  include <cairo-pdf.h>
 #endif
-#ifdef CAIRO_HAS_SVG_SURFACE
+#ifdef HAVE_RENDER_SVG
 #  include <cairo-svg.h>
 #endif
 #include <stdarg.h>
@@ -349,11 +349,11 @@ imagetype_string_to_type(const char *arg)
     return PPM;
   else if(! strcasecmp (arg, "png"))
     return PNG;
-#ifdef CAIRO_HAS_PDF_SURFACE
+#ifdef HAVE_RENDER_PDF
   else if(! strcasecmp(arg, "pdf"))
     return PDF;
 #endif
-#ifdef CAIRO_HAS_SVG_SURFACE
+#ifdef HAVE_RENDER_SVG
   else if(! strcasecmp(arg, "svg"))
     return SVG;
 #endif
@@ -375,11 +375,11 @@ imagetype_to_string(enum image_type type)
     {
     case PPM:
       return "ppm";
-#ifdef CAIRO_HAS_PDF_SURFACE
+#ifdef HAVE_RENDER_PDF
     case PDF:
       return "pdf";
 #endif
-#ifdef CAIRO_HAS_SVG_SURFACE
+#ifdef HAVE_RENDER_SVG
     case SVG:
       return "svg";
 #endif
@@ -509,7 +509,7 @@ image_recolor (cairo_surface_t * surface, const PopplerColor * fg,
     }
 }
 
-#if defined(CAIRO_HAS_PDF_SURFACE) || defined(CAIRO_HAS_SVG_SURFACE)
+#if defined(HAVE_RENDER_PDF) || defined(HAVE_RENDER_SVG)
 static void
 vector_image_recolor(cairo_t *cr, const PopplerColor * fg,
                      const PopplerColor * bg)
@@ -569,7 +569,7 @@ vector_surface_show_page(FILE * stream, cairo_surface_t *surface)
   vector_surface_stream = NULL;
   return TRUE;
 }
-#endif /* defined(CAIRO_HAS_PDF_SURFACE) || defined(CAIRO_HAS_SVG_SURFACE) */
+#endif /* defined(HAVE_RENDER_PDF) || defined(HAVE_RENDER_SVG) */
 
 /**
  * Initialize a cairo context based on the rendered image type, the PDF's
@@ -588,7 +588,7 @@ initialize_context (enum image_type imagetype, cairo_t *cr,
   switch(imagetype)
     {
     case PNG: case PPM:
-#ifdef CAIRO_HAS_SVG_SURFACE
+#ifdef HAVE_RENDER_SVG
     case SVG:
 #endif
       cairo_scale (cr, scale, scale);
@@ -619,7 +619,7 @@ set_surface_rectangle(enum image_type imagetype, cairo_rectangle_t *rect,
   rect->y = 0.0;
   switch(imagetype)
     {
-#ifdef CAIRO_HAS_PDF_SURFACE
+#ifdef HAVE_RENDER_PDF
     case PDF:
       rect->width = width;
       rect->height = height;
@@ -651,12 +651,12 @@ create_surface(enum image_type imagetype,
 
   switch(imagetype)
     {
-#ifdef CAIRO_HAS_PDF_SURFACE
+#ifdef HAVE_RENDER_PDF
     case PDF:
       return cairo_pdf_surface_create_for_stream
         (vector_surface_write_chunk, NULL, rect.width, rect.height);
 #endif
-#ifdef CAIRO_HAS_SVG_SURFACE
+#ifdef HAVE_RENDER_SVG
     case SVG:
       {
         cairo_surface_t *surface = cairo_svg_surface_create_for_stream
@@ -756,7 +756,7 @@ image_render_page(PopplerDocument *pdf, PopplerPage *page,
 
       if (options && options->usecolors)
         {
-#if defined(CAIRO_HAS_PDF_SURFACE) || defined(CAIRO_HAS_SVG_SURFACE)
+#if defined(HAVE_RENDER_PDF) || defined(HAVE_RENDER_SVG)
           if (vector_imagetype_p (imagetype))
             vector_image_recolor (cr, &options->fg, &options->bg);
           else
@@ -877,13 +877,13 @@ image_write (cairo_surface_t *surface, const char *filename, enum image_type typ
           fprintf (stderr, "Error writing png data\n");
       }
       break;
-#ifdef CAIRO_HAS_PDF_SURFACE
+#ifdef HAVE_RENDER_PDF
     case PDF:
 #endif
-#ifdef CAIRO_HAS_SVG_SURFACE
+#ifdef HAVE_RENDER_SVG
     case SVG:
 #endif
-#if defined(CAIRO_HAS_PDF_SURFACE) || defined(CAIRO_HAS_SVG_SURFACE)
+#if defined(HAVE_RENDER_PDF) || defined(HAVE_RENDER_SVG)
       success = vector_surface_show_page (file, surface);
       break;
 #endif
@@ -1163,17 +1163,17 @@ command_arg_parse_arg (const epdfinfo_t *ctx, const char *arg,
       }
     case ARG_IMAGETYPE:
       cerror_if_not (! strcmp (arg, "png")
-#ifdef CAIRO_HAS_PDF_SURFACE
+#ifdef HAVE_RENDER_PDF
                      || ! strcmp (arg, "pdf")
 #endif
-#ifdef CAIRO_HAS_SVG_SURFACE
+#ifdef HAVE_RENDER_SVG
                      || ! strcmp (arg, "svg")
 #endif
                      , error_msg, "Expected png"
-#ifdef CAIRO_HAS_PDF_SURFACE
+#ifdef HAVE_RENDER_PDF
                      " or pdf"
 #endif
-#ifdef CAIRO_HAS_SVG_SURFACE
+#ifdef HAVE_RENDER_SVG
                      " or svg"
 #endif
                      ":%s", arg);
@@ -2075,12 +2075,12 @@ cmd_features (const epdfinfo_t *ctx, const command_arg_t *args)
 #else
     "no-markup-annotations",
 #endif
-#ifdef CAIRO_HAS_PDF_SURFACE
+#ifdef HAVE_RENDER_PDF
     "render-pdf",
 #else
     "no-render-pdf",
 #endif
-#ifdef CAIRO_HAS_SVG_SURFACE
+#ifdef HAVE_RENDER_SVG
     "render-svg"
 #else
     "no-render-svg"

--- a/server/epdfinfo.h
+++ b/server/epdfinfo.h
@@ -20,6 +20,7 @@
 #include "config.h"
 #include <glib.h>
 #include <poppler.h>
+#include <cairo.h>
 #include <png.h>
 
 /* Some library functions print warnings to stdout, inhibit it. */
@@ -152,7 +153,11 @@
 
 enum suffix_char { NONE, COLON, NEWLINE};
 
-enum image_type { PNG = 0, PPM };
+enum image_type { PNG = 0, PPM
+#ifdef CAIRO_HAS_PDF_SURFACE
+                  , PDF
+#endif
+};
 
 typedef struct
 {

--- a/server/epdfinfo.h
+++ b/server/epdfinfo.h
@@ -20,7 +20,6 @@
 #include "config.h"
 #include <glib.h>
 #include <poppler.h>
-#include <cairo.h>
 #include <png.h>
 
 /* Some library functions print warnings to stdout, inhibit it. */
@@ -154,10 +153,10 @@
 enum suffix_char { NONE, COLON, NEWLINE};
 
 enum image_type { PNG = 0, PPM
-#ifdef CAIRO_HAS_PDF_SURFACE
+#ifdef HAVE_RENDER_PDF
                   , PDF
 #endif
-#ifdef CAIRO_HAS_SVG_SURFACE
+#ifdef HAVE_RENDER_SVG
                   , SVG
 #endif
 };

--- a/server/epdfinfo.h
+++ b/server/epdfinfo.h
@@ -152,7 +152,7 @@
 
 enum suffix_char { NONE, COLON, NEWLINE};
 
-enum image_type { PPM, PNG };
+enum image_type { PNG = 0, PPM };
 
 typedef struct
 {
@@ -164,6 +164,7 @@ typedef enum
   {
     ARG_INVALID = 0,
     ARG_DOC,
+    ARG_IMAGETYPE,
     ARG_BOOL,
     ARG_STRING,
     ARG_NONEMPTY_STRING,
@@ -188,6 +189,7 @@ typedef struct
   PopplerColor bg, fg;
   gboolean usecolors;
   gboolean printed;
+  enum image_type imagetype;
 } render_options_t;
 
 typedef struct
@@ -215,6 +217,7 @@ typedef struct
   {
     gboolean flag;
     const char *string;
+    enum image_type imagetype;
     long natnum;
     document_t *doc;
     gdouble edge;

--- a/server/epdfinfo.h
+++ b/server/epdfinfo.h
@@ -157,6 +157,9 @@ enum image_type { PNG = 0, PPM
 #ifdef CAIRO_HAS_PDF_SURFACE
                   , PDF
 #endif
+#ifdef CAIRO_HAS_SVG_SURFACE
+                  , SVG
+#endif
 };
 
 typedef struct


### PR DESCRIPTION
On retina displays, the PDF rendering can be fuzzy as mentioned in #51. This pull request adds support for rendering pages in the resolution independent formats, PDF and SVG whenever these formats are available.

To enable rendering using either PDF or SVG, the new variable `pdf-view-use-vector-graphics` can be set to `t`. Then when opening a PDF, the formats are tried in the order PDF -> SVG -> PNG. The PDF format is currently only available for the emacs-mac port using `image-io`.

After setting the above variable, SVG or PDF can be rendered if the function `pdf-view-vector-image-type` returns non-nil. See notes on performance issues related to SVG below.

Most likely there are features of `pdf-tools` that still need to be updated to consider vector image types. 

Also note, you will need to update to Cairo 1.16 for the SVG support. This is because I had to specifically set the units used in the generated SVG image to pixels and this feature is only available in Cairo >= 1.16. It looks like this is an issue with how Emacs handles the units of the width and height of an SVG image.

# Changes introduced

- Add a new `imagetype` epdfinfo command and `:render/imagetype` document option which is used to tell epdfinfo which image type (PNG, SVG, or PDF) should be used to render the pages of a document.
- Generalize Cairo surface creation and context initialization to take into account different image types.
- Bounding box calculation using `cairo_recording_surface_t` and `cairo_recording_surface_ink_extents` for vector image types.
- Midnight mode rendering for vector image types. This does not follow the same algorithm as for PNG images, but works pretty well. Maybe someone who is more familiar with [Cairo compositing operators](https://www.cairographics.org/operators/) can find a better algorithm.
- Update the `emacs-lisp` code to consider the above changes

# Some notes

## SVG rendering is slow

SVG rendering is extremely slow. I've tried ImageMagick, librsvg, and the SVG rendering supplied in the emacs-mac port using WebKit. For all three I am consistently seeing roughly 10-15 seconds of rendering time per page on a 2.5 GHz i5 13 inch. macbook pro. In contrast, the PDF rendering in the emacs-mac port gives around 0.3 second to render each page.

To get these numbers I wrapped the `image-size` call in `pdf-cache--prefetch-pages` like

```emacs-lisp
(let ((time (current-time)))
  (image-size (pdf-view-create-page page))
  (message "time %s" (float-time (time-subtract (current-time) time))))
```

## ImageMagick and SVG

ImageMagick doesn't seem to be that great at rendering SVG. It doesn't look to be any better than rendering as PNG images. So it may be better to render as SVG with `pdf-view-use-imagemagick` set to nil, i.e. using `librsvg` or the WebKit rendering in emacs-mac.

## Duplicates in the cache

I have found that duplicate entries are introduced into the cache, most likely related to the longer times it takes to render a page when using SVG or PDF. For example if you consider the following situation

1. Prefetcher requests some pages to be rendered

2. The pdf buffer is scrolled which stops the prefetcher, but the request for pages made in (1) are still being processed.

3. The user goes idle, starting the prefetcher once again after `pdf-cache-prefetch-delay` seconds

If some pages are still being cached from the call to the prefetcher in (1) by the time the prefetcher starts in (3), there is a possibility that another request to epdfinfo will be made for a page that has already been requested in (1), but has not been added to the cache yet. This seems to be because of the longer rendering times of SVG and PDF pages mentioned above. 

A simple solution would be to add some kind of pending request check besides just a cache lookup in `pdf-cache--prefetch-pages`.

