### PR TITLE
Add the ability to specify which installer to use

### DIFF
--- a/lisp/pdf-tools.el
+++ b/lisp/pdf-tools.el
@@ -206,6 +206,15 @@ PDF buffers."
 
 (defvar pdf-tools-msys2-directory nil)
 
+(defcustom pdf-tools-installer-os nil
+  "Specifies which installer to use.
+
+If nil the installer is chosen automatically. This variable is
+useful if you have multiple installers present on your
+system (e.g. nix on arch linux)"
+  :group 'pdf-tools
+  :type 'string)
+
 (defun pdf-tools-identify-build-directory (directory)
   "Return non-nil, if DIRECTORY appears to contain the epdfinfo source.
 
@@ -319,13 +328,14 @@ Returns the buffer of the compilation process."
             target-directory))
           (compilation-buffer
            (compilation-start
-            (format "%s -i %s%s"
+            (format "%s -i %s%s%s"
                     autobuild
                     (shell-quote-argument target-directory)
                     (cond
                      (skip-dependencies-p " -D")
                      (force-dependencies-p " -d")
-                     (t "")))
+                     (t ""))
+                    (if pdf-tools-installer-os (concat " --os " pdf-tools-installer-os) ""))
             t)))
       ;; In most cases user-input is required, so select the window.
       (if (get-buffer-window compilation-buffer)

--- a/server/autobuild
+++ b/server/autobuild
@@ -30,6 +30,8 @@ DRY_RUN=
 INSTALL_DIR=
 # Whether we can install packages.
 OS_IS_HANDLED=true
+# Which OSs installer to use
+OS=
 
 ## +-----------------------------------------------------------+
 ## * Utility Functions
@@ -38,17 +40,19 @@ OS_IS_HANDLED=true
 usage()
 {
     cat <<EOF
-usage:$(basename "$0") [--help|-n|[-i DIR|-I]]
+usage:$(basename "$0") [--help|-n|-i DIR|[-d -D]|[--os OS]]
 
-    -n      Don't do anything, but check if this OS is handled.
+    -n       Don't do anything, but check if this OS is handled.
 
-    -i DIR  Install the program in the given directory.
+    -i DIR   Install the program in the given directory.
 
-    -d      Force dependency installattion.
+    -d       Force dependency installattion.
 
-    -D      Skip dependency installattion.
+    -D       Skip dependency installattion.
 
-    --help  Display this message.
+    --os OS  Use the given OS's installer
+
+    --help   Display this message.
 
 EOF
     exit "$1"
@@ -185,6 +189,11 @@ handle_options()
                 if [ "${1%%/}" != "${PWD%%/}" ]; then
                     INSTALL_DIR=$1
                 fi ;;
+            --os)
+                shift
+                [ $# -gt 0 ] || usage 1
+                OS="$1"
+                ;;
             *) usage 1 ;;
         esac
         shift
@@ -406,16 +415,25 @@ os_gentoo() {
 
 handle_options "$@"
 
-os_macos   "$@" || \
-os_freebsd "$@" || \
-os_arch    "$@" || \
-os_centos  "$@" || \
-os_openbsd "$@" || \
-os_fedora  "$@" || \
-os_debian  "$@" || \
-os_gentoo  "$@" || \
-os_msys2   "$@" || \
-os_nixos   "$@" || \
+if [ -n "$OS" ]; then
+    OSES="freebsd arch centos openbsd fedora debain gentoo msys2 nixos"
+    if echo "$OSES" | grep "$OS" > /dev/null 2>&1; then
+        os_$OS "$@"
+    else
+        false
+    fi
+else
+    os_macos   "$@" || \
+    os_freebsd "$@" || \
+    os_arch    "$@" || \
+    os_centos  "$@" || \
+    os_openbsd "$@" || \
+    os_fedora  "$@" || \
+    os_debian  "$@" || \
+    os_gentoo  "$@" || \
+    os_msys2   "$@" || \
+    os_nixos   "$@"
+fi || \
 {
     OS_IS_HANDLED=
     if [ -z "$DRY_RUN" ]; then


### PR DESCRIPTION
This is useful when you have two installers on the same machine (e.g. pacman and nix-shell) and you want to choose between one of them.