### PR TITLE
Support high-resolution displays

### DIFF
--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -1594,7 +1594,7 @@ Return the data of the corresponding PNG image."
     'renderpage
     (pdf-info--normalize-file-or-buffer file-or-buffer)
     page
-    width
+    (* width (pdf-util-frame-scale-factor))
     (let (transformed)
       (while (cdr commands)
         (let ((kw (pop commands))

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -900,6 +900,8 @@ See also `pdf-view-use-imagemagick'."
   (cond ((and pdf-view-use-imagemagick
               (fboundp 'imagemagick-types))
          'imagemagick)
+        ((image-type-available-p 'image-io)
+         'image-io)
         ((image-type-available-p 'png)
          'png)
         ((fboundp 'imagemagick-types)
@@ -909,8 +911,8 @@ See also `pdf-view-use-imagemagick'."
 
 (defun pdf-view-use-scaling-p ()
   "Return t if scaling should be used."
-  (and (eq 'imagemagick
-           (pdf-view-image-type))
+  (and (memq (pdf-view-image-type)
+             '(imagemagick image-io))
        pdf-view-use-scaling))
 
 (defmacro pdf-view-create-image (data &rest props)
@@ -930,6 +932,9 @@ See also `pdf-view-use-imagemagick'."
                   (* 2 (car size)))))
          (hotspots (pdf-view-apply-hotspot-functions
                     window page size)))
+    (when (and (eq (framep-on-display) 'mac)
+               (= (pdf-util-frame-scale-factor) 2))
+      (put-text-property 0 1 :data-2x data data))
     (pdf-view-create-image data
       :width (car size)
       :map hotspots


### PR DESCRIPTION
As per the discussion in #461, it is more efficient to scale down a larger PNG image than it is to render as PDF or SVG in order to support high resolution displays.

This mainly implements the patch found in https://lists.gnu.org/archive/html/emacs-devel/2016-04/msg00648.html, but generalizes it in cases where `backing-scale-factor` (specific to the emacs-mac port) is not a frame attribute. The patch also adds the `:data-2x` property to the image data on supported systems to handle the case of mixing high-res and standard res displays according to https://lists.gnu.org/r/emacs-devel/2016-04/msg00890.html.