### PR TITLE
Don't go to initial page when activating `pdf-view-mode`

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -413,9 +413,7 @@ PNG images in Emacs buffers."
   (run-with-timer 1 nil (lambda (buffer)
                           (when (buffer-live-p buffer)
                             (pdf-view-check-incompatible-modes buffer)))
-		  (current-buffer))
-  ;; Setup initial page and start display
-  (pdf-view-goto-page (or (pdf-view-current-page) 1)))
+		  (current-buffer)))
 
 (unless (version< emacs-version "24.4")
   (defun cua-copy-region--pdf-view-advice (&rest _)


### PR DESCRIPTION
This pull request attempts to fix the issue where opening a PDF, `test2.pdf`, while the `selected-window` is visiting a different PDF, `test1.pdf`, would reset the page number of `test1.pdf`. This is the situation the commenter in https://github.com/politza/pdf-tools/issues/199#issuecomment-375475935 described.

The situation:

If the `selected-window` is visiting a file,`test1.pdf`, and I visit a file `test2.pdf` using `find-file`,  the `selected-window` will still be showing `test1.pdf` while the `current-buffer` will be `test2.pdf` when `pdf-view-mode` is activated for `test2.pdf`.

This is because `find-file` will display the file buffer in a window *after* the buffer's `major-mode` has been activated.

The issue:

The `pdf-view-goto-page` call in `pdf-view-mode` will use the PDF in the `selected-window` to set the `page`, but the `selected-window` is showing `test1.pdf`.

The solution:

Remove the call to `pdf-view-goto-page` in `pdf-view-mode` since the page will be set if it hasn't been already in `pdf-view-new-window-function` whenever a window displaying a PDF is shown.

A backtrace which shows the problem:

```
image-mode-window-put(page 1 t)
(if (eq t (car winprops)) nil (image-mode-window-put prop val t))
image-mode-window-put(page 1 #<window 4277 on test1.pdf>)
pdf-view-goto-page(1)
(let ((delay-mode-hooks t)) (special-mode) (setq major-mode (quote pdf-view-mode)) (setq mode-name "PDFView") (progn (if (get (quote special-mode) (quote mode-class)) (put (quote pdf-view-mode) (quote mode-class) (get (quote special-mode) (quote mode-class)))) (if (keymap-parent pdf-view-mode-map) nil (set-keymap-parent pdf-view-mode-map (current-local-map))) nil nil) (use-local-map pdf-view-mode-map) nil nil (if (and (or jka-compr-really-do-compress (let ((file-name-handler-alist nil)) (not (and buffer-file-name (file-readable-p buffer-file-name))))) (pdf-tools-pdf-buffer-p)) (progn (let ((tempfile (pdf-util-make-temp-file (concat ... "-")))) (write-region nil nil tempfile nil (quote no-message)) (set (make-local-variable (quote pdf-view--buffer-file-name)) tempfile)))) (pdf-view-decrypt-document) (if (boundp (quote mwheel-scroll-up-function)) (set (make-local-variable (quote mwheel-scroll-up-function)) (function pdf-view-scroll-up-or-next-page))) (if (boundp (quote mwheel-scroll-down-function)) (set (make-local-variable (quote mwheel-scroll-down-function)) (function pdf-view-scroll-down-or-previous-page))) (add-hook (quote change-major-mode-hook) (function (lambda nil (remove-overlays (point-min) (point-max) (quote pdf-view) t))) nil t) (remove-overlays (point-min) (point-max) (quote pdf-view) t) (set (make-local-variable (quote mode-line-position)) (quote (" P" (:eval (number-to-string (pdf-view-current-page))) "/" (:eval (or (ignore-errors (number-to-string ...)) "???"))))) (set (make-local-variable (quote auto-hscroll-mode)) nil) (set (make-local-variable (quote pdf-view--server-file-name)) (pdf-view-buffer-file-name)) (set (make-local-variable (quote scroll-conservatively)) 0) (set (make-local-variable (quote cursor-type)) nil) (set (make-local-variable (quote buffer-read-only)) t) (set (make-local-variable (quote view-read-only)) nil) (set (make-local-variable (quote bookmark-make-record-function)) (quote pdf-view-bookmark-make-record)) (set (make-local-variable (quote revert-buffer-function)) (function pdf-view-revert-buffer)) (set (make-local-variable (quote buffer-auto-save-file-name)) nil) (if buffer-undo-list nil (buffer-disable-undo)) (set (make-local-variable (quote transient-mark-mode)) t) (if (and (and (boundp (quote cua-mode)) cua-mode) (version< emacs-version "24.4")) (progn (set (make-local-variable (quote cua-mode)) nil))) (add-hook (quote window-configuration-change-hook) (quote pdf-view-maybe-redisplay-resized-windows) nil t) (add-hook (quote deactivate-mark-hook) (quote pdf-view-deactivate-region) nil t) (add-hook (quote write-contents-functions) (quote pdf-view--write-contents-function) nil t) (add-hook (quote kill-buffer-hook) (quote pdf-view-close-document) nil t) (pdf-view-add-hotspot-function (quote pdf-view-text-regions-hotspots-function) -9) (add-hook (quote image-mode-new-window-functions) (quote pdf-view-new-window-function) nil t) (image-mode-setup-winprops) (run-with-timer 1 nil (function (lambda (buffer) (if (buffer-live-p buffer) (progn (pdf-view-check-incompatible-modes buffer))))) (current-buffer)) (pdf-view-goto-page (or (image-mode-window-get (quote page) nil) 1)))
(progn (make-local-variable (quote delay-mode-hooks)) (let ((delay-mode-hooks t)) (special-mode) (setq major-mode (quote pdf-view-mode)) (setq mode-name "PDFView") (progn (if (get (quote special-mode) (quote mode-class)) (put (quote pdf-view-mode) (quote mode-class) (get (quote special-mode) (quote mode-class)))) (if (keymap-parent pdf-view-mode-map) nil (set-keymap-parent pdf-view-mode-map (current-local-map))) nil nil) (use-local-map pdf-view-mode-map) nil nil (if (and (or jka-compr-really-do-compress (let ((file-name-handler-alist nil)) (not (and buffer-file-name ...)))) (pdf-tools-pdf-buffer-p)) (progn (let ((tempfile (pdf-util-make-temp-file ...))) (write-region nil nil tempfile nil (quote no-message)) (set (make-local-variable (quote pdf-view--buffer-file-name)) tempfile)))) (pdf-view-decrypt-document) (if (boundp (quote mwheel-scroll-up-function)) (set (make-local-variable (quote mwheel-scroll-up-function)) (function pdf-view-scroll-up-or-next-page))) (if (boundp (quote mwheel-scroll-down-function)) (set (make-local-variable (quote mwheel-scroll-down-function)) (function pdf-view-scroll-down-or-previous-page))) (add-hook (quote change-major-mode-hook) (function (lambda nil (remove-overlays (point-min) (point-max) (quote pdf-view) t))) nil t) (remove-overlays (point-min) (point-max) (quote pdf-view) t) (set (make-local-variable (quote mode-line-position)) (quote (" P" (:eval (number-to-string (pdf-view-current-page))) "/" (:eval (or (ignore-errors ...) "???"))))) (set (make-local-variable (quote auto-hscroll-mode)) nil) (set (make-local-variable (quote pdf-view--server-file-name)) (pdf-view-buffer-file-name)) (set (make-local-variable (quote scroll-conservatively)) 0) (set (make-local-variable (quote cursor-type)) nil) (set (make-local-variable (quote buffer-read-only)) t) (set (make-local-variable (quote view-read-only)) nil) (set (make-local-variable (quote bookmark-make-record-function)) (quote pdf-view-bookmark-make-record)) (set (make-local-variable (quote revert-buffer-function)) (function pdf-view-revert-buffer)) (set (make-local-variable (quote buffer-auto-save-file-name)) nil) (if buffer-undo-list nil (buffer-disable-undo)) (set (make-local-variable (quote transient-mark-mode)) t) (if (and (and (boundp (quote cua-mode)) cua-mode) (version< emacs-version "24.4")) (progn (set (make-local-variable (quote cua-mode)) nil))) (add-hook (quote window-configuration-change-hook) (quote pdf-view-maybe-redisplay-resized-windows) nil t) (add-hook (quote deactivate-mark-hook) (quote pdf-view-deactivate-region) nil t) (add-hook (quote write-contents-functions) (quote pdf-view--write-contents-function) nil t) (add-hook (quote kill-buffer-hook) (quote pdf-view-close-document) nil t) (pdf-view-add-hotspot-function (quote pdf-view-text-regions-hotspots-function) -9) (add-hook (quote image-mode-new-window-functions) (quote pdf-view-new-window-function) nil t) (image-mode-setup-winprops) (run-with-timer 1 nil (function (lambda (buffer) (if (buffer-live-p buffer) (progn (pdf-view-check-incompatible-modes buffer))))) (current-buffer)) (pdf-view-goto-page (or (image-mode-window-get (quote page) nil) 1))))
pdf-view-mode()
set-auto-mode-0(pdf-view-mode nil)
set-auto-mode()
normal-mode(t)
after-find-file(nil t)
find-file-noselect-1(#<buffer test2.pdf> "~/test2.pdf" nil nil "~/test2.pdf" (69337035 16777220))
find-file-noselect("/Users/nathan/test2.pdf" nil nil nil)
find-file("/Users/nathan/test2.pdf")
```
