### PR TITLE
Add function for returning current page label

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -242,6 +242,9 @@ regarding display of the region in the later function.")
   ;;TODO: write documentation!
   `(image-mode-window-get 'window-size ,window))
 
+(defun pdf-view-current-pagelabel (&optional window)
+  (nth (1- (pdf-view-current-page window)) (pdf-info-pagelabels)))
+
 (defun pdf-view-active-region-p nil
   "Return t if there are active regions."
   (not (null pdf-view-active-region)))


### PR DESCRIPTION
This is helpful for instance for a modeline display that shows both physical pages and labels.

As an example, I now define this function for doom-modeline:

    (defun aj/doom-modeline-update-pdf-pages ()
      "Update PDF pages. Use pagelabels if available."
      (setq doom-modeline--pdf-pages
            (let* ((cp (eval `(pdf-view-current-page)))
               (physical (format "P%d/%d"
                                 cp
                                 (pdf-cache-number-of-pages)))
               (currlabel (pdf-view-current-pagelabel)))
          (propertize
           (if (equal currlabel (number-to-string cp))
               (concat " " physical " ")
             (concat " " currlabel " (" physical ") "))
           'face (if (doom-modeline--active)
                     'mode-line
                   'mode-line-inactive)))))