### PR TITLE
Fix definition of pdf-cache-prefetch-minor-mode keymap

### DIFF
--- a/lisp/pdf-cache.el
+++ b/lisp/pdf-cache.el
@@ -338,7 +338,7 @@ See also `pdf-info-renderpage-highlight' and
 
 (define-minor-mode pdf-cache-prefetch-minor-mode
   "Try to load images which will probably be needed in a while."
-  nil nil t
+  nil nil nil
   (pdf-cache--prefetch-cancel)
   (cond
    (pdf-cache-prefetch-minor-mode


### PR DESCRIPTION
`t` is not a valid keymap.  I looked through the other minor-mode
definitions and didn't see any other such uses.

Found that this was causing me problems, see Wilfred/helpful#114.