### PR TITLE
Fix the inability to scroll to next page in Emacs 27

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -716,7 +716,10 @@ next page only on typing SPC (ARG is nil)."
   (if (or pdf-view-continuous (null arg))
       (let ((hscroll (window-hscroll))
             (cur-page (pdf-view-current-page)))
-        (when (or (= (window-vscroll) (image-scroll-up arg))
+        (when (or (= (window-vscroll)
+                     (progn
+                       (image-scroll-up arg)
+                       (window-vscroll)))
                   ;; Workaround rounding/off-by-one issues.
                   (memq pdf-view-display-size
                         '(fit-height fit-page)))
@@ -757,7 +760,10 @@ at the bottom edge of the page moves to the next page."
   (if pdf-view-continuous
       (let ((hscroll (window-hscroll))
             (cur-page (pdf-view-current-page)))
-        (when (= (window-vscroll) (image-next-line arg))
+        (when (= (window-vscroll)
+                 (progn
+                       (image-next-line arg)
+                       (window-vscroll)))
           (pdf-view-next-page)
           (when (/= cur-page (pdf-view-current-page))
             (image-bob)


### PR DESCRIPTION
When reaching the end of a document page, `image-scroll-up` and `image-next-line` don't return the same value as `window-vscroll`.

Therefore we need to try to `image-scroll-up` or `image-next-line` first. If we can scroll, then `(window-vscroll)` will return a different value prior to scroll-up or next-line