### PR TITLE
'set-window-hscroll does not update image-mode's hscroll value

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -729,7 +729,7 @@ next page only on typing SPC (ARG is nil)."
           (when (/= cur-page (pdf-view-current-page))
             (image-bob)
             (image-bol 1))
-          (set-window-hscroll (selected-window) hscroll)))
+          (image-set-window-hscroll hscroll)))
     (image-scroll-up arg)))
 
 (defun pdf-view-scroll-down-or-previous-page (&optional arg)
@@ -751,7 +751,7 @@ to previous page only on typing DEL (ARG is nil)."
           (when (/= cur-page (pdf-view-current-page))
             (image-eob)
             (image-bol 1))
-          (set-window-hscroll (selected-window) hscroll)))
+          (image-set-window-hscroll hscroll)))
     (image-scroll-down arg)))
 
 (defun pdf-view-next-line-or-next-page (&optional arg)
@@ -769,7 +769,7 @@ at the bottom edge of the page moves to the next page."
           (when (/= cur-page (pdf-view-current-page))
             (image-bob)
             (image-bol 1))
-          (set-window-hscroll (selected-window) hscroll)))
+          (image-set-window-hscroll hscroll)))
     (image-next-line 1)))
 
 (defun pdf-view-previous-line-or-previous-page (&optional arg)
@@ -787,7 +787,7 @@ at the top edge of the page moves to the previous page."
           (when (/= cur-page (pdf-view-current-page))
             (image-eob)
             (image-bol 1))
-          (set-window-hscroll (selected-window) hscroll)))
+          (image-set-window-hscroll hscroll)))
     (image-previous-line arg)))
 
 (defun pdf-view-goto-label (label)


### PR DESCRIPTION
image-mode keeps it's own copy of hscroll and during redisplay it will
grab that value and use it. If you don't update image-mode's hscroll,
but directly set the window's hscroll you will (after triggering a redisplay)
find your pdf scrolled all the way to the left margin. Quite unfortunate
if you happen to be zoomed in. This fixes that by using image-mode's
method for updating hscroll