### PR TITLE
Fix "undefined function" errors with native-comp

### DIFF
--- a/lisp/pdf-cache.el
+++ b/lisp/pdf-cache.el
@@ -23,6 +23,7 @@
 ;;; Code:
 ;;
 
+(require 'pdf-macs)
 (require 'pdf-info)
 (require 'pdf-util)
 

--- a/lisp/pdf-macs.el
+++ b/lisp/pdf-macs.el
@@ -1,0 +1,51 @@
+;;; pdf-macs.el --- Macros for pdf-tools. -*- lexical-binding:t -*-
+
+;; Copyright (C) 2013  Andreas Politz
+
+;; Author: Andreas Politz <politza@fh-trier.de>
+;; Keywords: files, doc-view, pdf
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;;; Code:
+;;
+
+(defmacro pdf-view-current-page (&optional window)
+  ;;TODO: write documentation!
+  `(image-mode-window-get 'page ,window))
+
+(defmacro pdf-view-current-overlay (&optional window)
+  ;;TODO: write documentation!
+  `(image-mode-window-get 'overlay ,window))
+
+(defmacro pdf-view-current-image (&optional window)
+  ;;TODO: write documentation!
+  `(image-mode-window-get 'image ,window))
+
+(defmacro pdf-view-current-slice (&optional window)
+  ;;TODO: write documentation!
+  `(image-mode-window-get 'slice ,window))
+
+(defmacro pdf-view-current-window-size (&optional window)
+  ;;TODO: write documentation!
+  `(image-mode-window-get 'window-size ,window))
+
+(defmacro pdf-view-window-needs-redisplay (&optional window)
+  `(image-mode-window-get 'needs-redisplay ,window))
+
+(provide 'pdf-macs)
+
+;;; pdf-macs.el ends here

--- a/lisp/pdf-util.el
+++ b/lisp/pdf-util.el
@@ -25,6 +25,7 @@
 
 ;;; Code:
 
+(require 'pdf-macs)
 (require 'cl-lib)
 (require 'format-spec)
 (require 'faces)

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'image-mode)
+(require 'pdf-macs)
 (require 'pdf-util)
 (require 'pdf-info)
 (require 'pdf-cache)
@@ -221,29 +222,6 @@ regarding display of the region in the later function.")
 
 (defvar-local pdf-view-register-alist nil
   "Local, dedicated register for PDF positions.")
-
-(defmacro pdf-view-current-page (&optional window)
-  ;;TODO: write documentation!
-  `(image-mode-window-get 'page ,window))
-
-(defmacro pdf-view-current-overlay (&optional window)
-  ;;TODO: write documentation!
-  `(image-mode-window-get 'overlay ,window))
-
-(defmacro pdf-view-current-image (&optional window)
-  ;;TODO: write documentation!
-  `(image-mode-window-get 'image ,window))
-
-(defmacro pdf-view-current-slice (&optional window)
-  ;;TODO: write documentation!
-  `(image-mode-window-get 'slice ,window))
-
-(defmacro pdf-view-current-window-size (&optional window)
-  ;;TODO: write documentation!
-  `(image-mode-window-get 'window-size ,window))
-
-(defmacro pdf-view-window-needs-redisplay (&optional window)
-  `(image-mode-window-get 'needs-redisplay ,window))
 
 (defun pdf-view-current-pagelabel (&optional window)
   (nth (1- (pdf-view-current-page window)) (pdf-info-pagelabels)))


### PR DESCRIPTION
This solves an error that arises from compiling pdf-tools.  The `pdf-view-current-page` macro isn't visible in `pdf-cache.el`, so the compiler assumes it's a function to be defined later.  We then get an error about undefined function every time `pdf-cache--prefetch-start` is called.

I took the "nuclear" approach of solving this by moving the macros from `pdf-view.el` out into their own file, though it may be solvable with some more careful re-shuffling if you prefer.