### PR TITLE
fixup! Fix typos -- Resolves error with pdf-misc-print-document

### DIFF
--- a/lisp/pdf-misc.el
+++ b/lisp/pdf-misc.el
@@ -236,7 +236,7 @@
 
 (define-obsolete-variable-alias 'pdf-misc-print-programm
   'pdf-misc-print-program "1.0")
-(defcustom pdf-misc-print-programm nil
+(defcustom pdf-misc-print-program nil
   "The program used for printing.
 
 It is called with one argument, the PDF file."
@@ -245,14 +245,14 @@ It is called with one argument, the PDF file."
 
 (define-obsolete-variable-alias 'pdf-misc-print-programm-args
   'pdf-misc-print-program-args "1.0")
-(defcustom pdf-misc-print-programm-args nil
+(defcustom pdf-misc-print-program-args nil
   "List of additional arguments passed to `pdf-misc-print-program'."
   :group 'pdf-misc
   :type '(repeat string))
 
-(defun pdf-misc-print-programm (&optional interactive-p)
-  (or (and pdf-misc-print-programm
-           (executable-find pdf-misc-print-programm))
+(defun pdf-misc-print-program (&optional interactive-p)
+  (or (and pdf-misc-print-program
+           (executable-find pdf-misc-print-program))
       (when interactive-p
         (let* ((default (car (delq nil (mapcar
                                         'executable-find
@@ -274,7 +274,7 @@ It is called with one argument, the PDF file."
    (list (pdf-view-buffer-file-name) t))
   (cl-check-type filename (and string file-readable))
   (let ((program (pdf-misc-print-program interactive-p))
-        (args (append pdf-misc-print-programm-args (list filename))))
+        (args (append pdf-misc-print-program-args (list filename))))
     (unless program
       (error "No print program available"))
     (apply #'start-process "printing" nil program args)


### PR DESCRIPTION
Fixup for commit 2ece5084c213def6ef6721f84867dae3fed77fd2 which triggered the error "Symbol’s function definition is void: `pdf-misc-print-program`" when `M-x pdf-misc-print-document` is used.

Fixes issue #590.

This PR supersedes #578 (which is missing some of the required changes).