### PR TITLE
add option to customize fill-column in pdf outlines

### DIFF
--- a/lisp/pdf-outline.el
+++ b/lisp/pdf-outline.el
@@ -74,6 +74,13 @@ Usually a page's label is it's displayed page number."
   :group 'pdf-outline
   :type 'boolean)
 
+(defcustom pdf-outline-fill-column fill-column
+  "The value of `fill-column' in pdf outline buffers.
+
+Set to nil to disable line wrapping."
+  :group 'pdf-outline
+  :type 'integer)
+
 (defvar pdf-outline-minor-mode-map
   (let ((km (make-sparse-keymap)))
     (define-key km (kbd "o") 'pdf-outline)
@@ -229,6 +236,7 @@ buffer, unless NO-SELECT-WINDOW-P is non-nil."
            (buffer-exists-p (get-buffer bname))
            (buffer (get-buffer-create bname)))
       (with-current-buffer buffer
+        (setq-local fill-column pdf-outline-fill-column)
         (unless buffer-exists-p
           (when (= 0 (save-excursion
                        (pdf-outline-insert-outline pdf-buffer)))


### PR DESCRIPTION
This PR resolves [this issue](https://github.com/politza/pdf-tools/issues/593). Specifically, it gives the user the option to disable the action of `fill-column` (or customize it to whatever they want) in pdf-outline buffers. This is useful because outlines frequently contain long lines, and breaking up the lines destroys the formatting and integrity of the outline. Please let me know if any concerns, etc.

An alternative solution, which would be more general purpose would be to add a hook that is invoked before the outline is inserted into the outline buffer. If you'd prefer a solution like this to the one I've provided which is specific to `fill-column`, let me know and I'll look into it.