### PR TITLE
Avoid using `declare-function' on macros in pdf-utils.el

### DIFF
--- a/lisp/pdf-util.el
+++ b/lisp/pdf-util.el
@@ -33,12 +33,21 @@
 ;; which won't succeed, if pdf-view.el isn't loaded.
 (declare-function pdf-view-image-size "pdf-view")
 (declare-function pdf-view-image-offset "pdf-view")
-(declare-function pdf-view-current-image "pdf-view")
-(declare-function pdf-view-current-overlay "pdf-view")
 (declare-function pdf-cache-pagesize "pdf-cache")
 
 (declare-function pdf-view-image-type "pdf-view")
 
+;; ...similarly for these macros (originally in pdf-view.el). Using
+;; `declare-function' on these causes errors when using pdf-tools under Emacs
+;; 28's new native compilation.
+;; See https://lists.gnu.org/archive/html/bug-gnu-emacs/2020-09/msg02502.html
+(defmacro pdf-view-current-overlay (&optional window)
+  ;;TODO: write documentation!
+  `(image-mode-window-get 'overlay ,window))
+
+(defmacro pdf-view-current-image (&optional window)
+  ;;TODO: write documentation!
+  `(image-mode-window-get 'image ,window))
 
 
 ;; * ================================================================== *

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -226,14 +226,6 @@ regarding display of the region in the later function.")
   ;;TODO: write documentation!
   `(image-mode-window-get 'page ,window))
 
-(defmacro pdf-view-current-overlay (&optional window)
-  ;;TODO: write documentation!
-  `(image-mode-window-get 'overlay ,window))
-
-(defmacro pdf-view-current-image (&optional window)
-  ;;TODO: write documentation!
-  `(image-mode-window-get 'image ,window))
-
 (defmacro pdf-view-current-slice (&optional window)
   ;;TODO: write documentation!
   `(image-mode-window-get 'slice ,window))


### PR DESCRIPTION
This would close #625. 

As described in that issue, using `declare-function' on macros causes errors under Emacs 28's new native compilation.

This is a bit of a brutish solution, but obviously requiring pdf-view in pdf-utils causes a recursive requirement. I had considered just inlining the macro's definition in each place in pdf-utils.el, but felt this was cleaner (especially because it fit with the `declare-function' block near the top of the file).