### PR TITLE
Fix the AppVeyor build errors  

### DIFF
--- a/ci/appveyor/install.bat
+++ b/ci/appveyor/install.bat
@@ -26,5 +26,5 @@ IF %COMPILER%==msys2 (
   bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-emacs"
 
   REM Set up Cask
-  bash -lc "curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python"
+  bash -lc "curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python2"
 )


### PR DESCRIPTION
This changes the AppVeyor config to run the Cask installation script under Python 2, rather than Python 3, and hopefully fix the [build errors](https://ci.appveyor.com/project/politza/pdf-tools/builds/35499187).

According to cask/cask#382, Cask doesn't play well being run under Windows and Python 3. Per msys2/MINGW-packages#4950, MINGW switched `python` to version 3 in August 2019, leading to these errors around then.

Update: Seems to have worked, given this build passes.