### PR TITLE
Add pdf-virtual-global-minor-mode to pdf-tools custom group

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,2 @@
+((emacs-lisp-mode
+  (indent-tabs-mode . nil)))

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,2 +1,3 @@
 ((emacs-lisp-mode
-  (indent-tabs-mode . nil)))
+  (indent-tabs-mode . nil)
+  (outline-regexp . ";;\\(\\(?:;+\\| \\*+\\) [^=\s\t\n]\\|###autoload\\)\\|(")))

--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -224,7 +224,7 @@ annoyed while reading the annotations."
 A function on this hook should accept one argument: A CLOSURE
 containing inserted, changed and deleted annotations.
 
-It may access theses annotations by calling CLOSURE with one of
+It may access these annotations by calling CLOSURE with one of
 these arguments:
 
 `:inserted' The list of recently added annotations.

--- a/lisp/pdf-misc.el
+++ b/lisp/pdf-misc.el
@@ -236,7 +236,7 @@
 
 (define-obsolete-variable-alias 'pdf-misc-print-programm
   'pdf-misc-print-program "1.0")
-(defcustom pdf-misc-print-programm nil
+(defcustom pdf-misc-print-program nil
   "The program used for printing.
 
 It is called with one argument, the PDF file."
@@ -245,14 +245,14 @@ It is called with one argument, the PDF file."
 
 (define-obsolete-variable-alias 'pdf-misc-print-programm-args
   'pdf-misc-print-program-args "1.0")
-(defcustom pdf-misc-print-programm-args nil
+(defcustom pdf-misc-print-program-args nil
   "List of additional arguments passed to `pdf-misc-print-program'."
   :group 'pdf-misc
   :type '(repeat string))
 
-(defun pdf-misc-print-programm (&optional interactive-p)
-  (or (and pdf-misc-print-programm
-           (executable-find pdf-misc-print-programm))
+(defun pdf-misc-print-program (&optional interactive-p)
+  (or (and pdf-misc-print-program
+           (executable-find pdf-misc-print-program))
       (when interactive-p
         (let* ((default (car (delq nil (mapcar
                                         'executable-find
@@ -274,7 +274,7 @@ It is called with one argument, the PDF file."
    (list (pdf-view-buffer-file-name) t))
   (cl-check-type filename (and string file-readable))
   (let ((program (pdf-misc-print-program interactive-p))
-        (args (append pdf-misc-print-programm-args (list filename))))
+        (args (append pdf-misc-print-program-args (list filename))))
     (unless program
       (error "No print program available"))
     (apply #'start-process "printing" nil program args)

--- a/lisp/pdf-virtual.el
+++ b/lisp/pdf-virtual.el
@@ -26,7 +26,7 @@
 ;; order to transparently make this collection appear as one single
 ;; document.
 ;;
-;; The trickiest part is to make theses intermediate functions behave
+;; The trickiest part is to make these intermediate functions behave
 ;; like the pdf-info-* equivalents in both the synchronous and
 ;; asynchronous case.
 
@@ -518,7 +518,7 @@ PAGE should be a page-number."
                             (concat " " f))
                           unreadable "\n"))))
     (if (= (pdf-virtual-document-number-of-pages) 0)
-        (error "Docüment is empty.")
+        (error "Document is empty.")
       (unless pdf-virtual-global-minor-mode
         (pdf-virtual-global-minor-mode 1))
       (funcall fn))))

--- a/lisp/pdf-virtual.el
+++ b/lisp/pdf-virtual.el
@@ -479,6 +479,7 @@ PAGE should be a page-number."
   "Enable recognition and handling of VPDF files."
   nil nil nil
   :global t
+  :group 'pdf-tools
   (let ((elt `(,pdf-virtual-magic-mode-regexp . pdf-virtual-view-mode)))
     (cond
      (pdf-virtual-global-minor-mode

--- a/server/synctex_parser.c
+++ b/server/synctex_parser.c
@@ -7592,7 +7592,7 @@ static synctex_nd_s _synctex_point_h_ordered_distance_v2
         int min,med,max,width;
         switch(synctex_node_type(node)) {
                 /*  The distance between a point and a box is special.
-                 *  It is not the euclidian distance, nor something similar.
+                 *  It is not the euclidean distance, nor something similar.
                  *  We have to take into account the particular layout,
                  *  and the box hierarchy.
                  *  Given a box, there are 9 regions delimited by the lines of the edges of the box.
@@ -7733,7 +7733,7 @@ static synctex_nd_s _synctex_point_v_ordered_distance_v2
     int min,max,depth,height;
     switch(synctex_node_type(node)) {
             /*  The distance between a point and a box is special.
-             *  It is not the euclidian distance, nor something similar.
+             *  It is not the euclidean distance, nor something similar.
              *  We have to take into account the particular layout,
              *  and the box hierarchy.
              *  Given a box, there are 9 regions delimited by the lines of the edges of the box.
@@ -7881,7 +7881,7 @@ SYNCTEX_INLINE static synctex_bool_t _synctex_point_in_box_v2(synctex_point_p hi
 
 static int _synctex_distance_to_box_v2(synctex_point_p hit,synctex_box_p box) {
     /*  The distance between a point and a box is special.
-     *  It is not the euclidian distance, nor something similar.
+     *  It is not the euclidean distance, nor something similar.
      *  We have to take into account the particular layout,
      *  and the box hierarchy.
      *  Given a box, there are 9 regions delimited by the lines of the edges of the box.


### PR DESCRIPTION
This silences the byte-compiler, which would complain about the group not being specified.

The byte-compiler has a few additional complains and it would be nice if you could address those:

```
Compiling /home/jonas/.emacs.d/lib/pdf-tools/lisp/pdf-links.el...

In pdf-links-browse-uri-default:
lib/pdf-tools/lisp/pdf-links.el:372:4: Warning: ‘org-open-link-from-string’ is
    an obsolete function (as of Org 9.3); use ‘org-link-open-from-string’
    instead.
Compiling /home/jonas/.emacs.d/lib/pdf-tools/lisp/pdf-loader.el...
Compiling /home/jonas/.emacs.d/lib/pdf-tools/lisp/pdf-misc.el...
Compiling /home/jonas/.emacs.d/lib/pdf-tools/lisp/pdf-view.el...

In pdf-view-registerv-make:
lib/pdf-tools/lisp/pdf-view.el:1601:4: Warning: ‘registerv-make’ is an
    obsolete function (as of 27.1); Use your own type with methods on
    register-val-(insert|describe|jump-to)
```