### PR TITLE
Fix colors hint command

### DIFF
--- a/lisp/pdf-links.el
+++ b/lisp/pdf-links.el
@@ -51,8 +51,8 @@
 (defcustom pdf-links-read-link-convert-commands
   '(;;"-font" "FreeMono"
     "-pointsize" "%P"
-    "-undercolor" "%f"
-    "-fill" "%b"
+    "-undercolor" "%b"
+    "-fill" "%f"
     "-draw" "text %X,%Y '%c'")
 
   "The commands for the convert program, when decorating links for reading.


### PR DESCRIPTION
This swaps the foreground and background colors of hints to match the behavior of Emacs, i.e., `:foreground` for `-draw` and `:background` for `-undercolor`.