### PR TITLE
Fix a bug in vscrolling in emacs27

### DIFF
--- a/lisp/pdf-util.el
+++ b/lisp/pdf-util.el
@@ -696,7 +696,9 @@ string."
             ,@tooltip-frame-parameters))
          (tooltip-hide-delay (or timeout 3)))
     (when vscroll
-      (image-set-window-vscroll vscroll))
+      (image-set-window-vscroll (* vscroll
+				   (if pdf-view-have-image-mode-pixel-vscroll
+				       (frame-char-height) 1))))
     (setq dy (max 0 (- dy
                        (cdr (pdf-view-image-offset))
                        (window-vscroll nil t)


### PR DESCRIPTION
Fix https://github.com/politza/pdf-tools/issues/604. There are probably other incorrect places in the code (eg pdf-util-scroll-to-edges looks fishy), but I don't understand it very well so I'm leaving as is.