### PR TITLE
Don’t record temporary window selection changes

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -850,7 +850,7 @@ Return nil, if no annotation was found."
       (setq window (posn-window pos)
             pos (posn-object-x-y pos)))
     (save-selected-window
-      (when window (select-window window))
+      (when window (select-window window 'norecord))
       (let* ((annots (pdf-annot-getannots (pdf-view-current-page)))
              (size (pdf-view-image-size))
              (rx (/ (car pos) (float (car size))))
@@ -968,7 +968,7 @@ If HIGHLIGHT-P is non-nil, visually distinguish annotation A from
 other annotations."
 
   (save-selected-window
-    (when window (select-window window))
+    (when window (select-window window 'norecord))
     (pdf-util-assert-pdf-window)
     (let ((page (pdf-annot-get a 'page))
           (size (pdf-view-image-size)))

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -626,7 +626,7 @@ windows."
   (save-selected-window
     ;; Select the window for the hooks below.
     (when (window-live-p window)
-      (select-window window))
+      (select-window window 'norecord))
     (let ((changing-p
            (not (eq page (pdf-view-current-page window)))))
       (when changing-p
@@ -1261,7 +1261,7 @@ supersede hotspots in lower ones."
   ;; TODO: write documentation!
   (unless pdf-view-inhibit-hotspots
     (save-selected-window
-      (when window (select-window window))
+      (when window (select-window window 'norecord))
       (apply 'nconc
              (mapcar (lambda (fn)
                        (funcall fn page image-size))

--- a/lisp/pdf-virtual.el
+++ b/lisp/pdf-virtual.el
@@ -567,7 +567,7 @@ PAGE should be a page-number."
 
 (defun pdf-virtual-view-window-p (&optional window)
   (save-selected-window
-    (when window (select-window window))
+    (when window (select-window window 'norecord))
     (derived-mode-p 'pdf-virtual-view-mode)))
 
 (defun pdf-virtual-filename-p (filename)


### PR DESCRIPTION
There are places with code similar to the following:

      (save-selected-window
        (select-window window)
        …)

For the purposes of this commit, this is roughly equivalent to:

      (let ((old-window (selected-window)))
        (select-window window)
        …
        (select-window old-window 'norecord))

That is, when ‘save-selected-window’ restores the state, it passes
‘norecord’ argument to ‘select-window’ function.  As a result, when
selected window is initially changed ‘buffer-list-update-hook’ is
called however it is not invoked when selected window is restored.
This confuses any code using that hook to track selected window.

To address this issue, change calls such as the above to use
‘norecord’ argument.  This way, ‘buffer-list-update-hook’ is called
neither when the new window is temporarily selected nor when old
window is restored.

For reference, this is indeed what documentation of ‘select-window’
says should be done:

> Run ‘buffer-list-update-hook’ unless NORECORD is non-nil.  Note that
> applications […] often select a window temporarily […]  to simplify
> coding.  As a rule, such selections should not be recorded and
> therefore will not pollute ‘buffer-list-update-hook’.  Selections
> that "really count" are those causing a visible change in the next
> redisplay of WINDOW’s frame and should always be recorded.

Fixes: https://github.com/mina86/auto-dim-other-buffers.el/issues/26