### PR TITLE
Correct it's -> its

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -76,7 +76,7 @@
     not at page boundaries.
 ** View
 *** Navigate by pagelabels
-    M-g l may be used to jump to a page by label, i.e. it's displayed
+    M-g l may be used to jump to a page by label, i.e. its displayed
     number.
 *** Rendering
     Added the ability to display the page as it would be printed
@@ -108,7 +108,7 @@
    by setting pdf-tools-handle-upgrades to nil.
 ** Auto slicing
    A new minor mode which will automatically slice the page according
-   to it's bounding box.
+   to its bounding box.
 * Version 0.40
   I basically reimplemented the whole thing. (Not really, but a lot
   has changed.)

--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -678,7 +678,7 @@ The DO-SAVE argument is given to
 
 
 (defun pdf-annot-attachment-save (attachment &optional regenerate-p)
-  "Save ATTACHMENT's data to a unique filename and return it's name.
+  "Save ATTACHMENT's data to a unique filename and return its name.
 
 If REGENERATE-P is non-nil, copy attachment's file even if the
 copy already exists.

--- a/lisp/pdf-cache.el
+++ b/lisp/pdf-cache.el
@@ -89,7 +89,7 @@ be prefetched and their order."
   "Get value of KEY in the cache of PAGE.
 
 Returns a cons \(HIT . VALUE\), where HIT is non-nil if KEY was
-stored previously for PAGE and VALUE it's value.  Otherwise HIT
+stored previously for PAGE and VALUE its value.  Otherwise HIT
 is nil and VALUE undefined."
   (pdf-cache--initialize)
   (let ((elt (assq key (gethash page pdf-cache--data))))
@@ -130,7 +130,7 @@ Both args are unevaluated."
         (ifn (intern (format "pdf-info-%s" command)))
         (doc (format "Cached version of `pdf-info-%s', which see.
 
-Make sure, not to modify it's return value." command)))
+Make sure, not to modify its return value." command)))
     `(defun ,fn ,args
        ,doc
        (let ((hit-value (pdf-cache--data-get ',command ,(if page-arg-p 'page))))
@@ -172,8 +172,8 @@ Make sure, not to modify it's return value." command)))
 
 IMAGE should be a list as created by `pdf-cache--make-image'.
 
-Return non-nil, if IMAGE's page is the same as PAGE, it's width
-is at least MIN-WIDTH and at most MAX-WIDTH and it's stored
+Return non-nil, if IMAGE's page is the same as PAGE, its width
+is at least MIN-WIDTH and at most MAX-WIDTH and its stored
 hash-value is `eql' to HASH."
   (and (= (pdf-cache--image/page image)
           page)
@@ -278,7 +278,7 @@ from the cache."
 (defun pdf-cache-renderpage (page min-width &optional max-width)
   "Render PAGE according to MIN-WIDTH and MAX-WIDTH.
 
-Return the PNG data of an image as a string, such that it's width
+Return the PNG data of an image as a string, such that its width
 is at least MIN-WIDTH and, if non-nil, at most MAX-WIDTH.
 
 If such an image is not available in the cache, call
@@ -344,7 +344,7 @@ See also `pdf-info-renderpage-highlight' and
    (pdf-cache-prefetch-minor-mode
     (pdf-util-assert-pdf-buffer)
     (add-hook 'pre-command-hook 'pdf-cache--prefetch-stop nil t)
-    ;; FIXME: Disable the time when the buffer is killed or it's
+    ;; FIXME: Disable the time when the buffer is killed or its
     ;; major-mode changes.
     (setq pdf-cache--prefetch-timer
           (run-with-idle-timer (or pdf-cache-prefetch-delay 1)

--- a/lisp/pdf-occur.el
+++ b/lisp/pdf-occur.el
@@ -78,7 +78,7 @@ the cost of slightly increased search time."
 
 Each element should be either the filename of a PDF document or a
 cons \(FILENAME . PAGES\), where PAGES is the list of pages to
-search.  See `pdf-info-normalize-page-range' for it's format.")
+search.  See `pdf-info-normalize-page-range' for its format.")
 
 (defvar pdf-occur-number-of-matches 0
   "The number of matches in all searched documents.")
@@ -453,7 +453,7 @@ I.e. all marked files look like PDF documents."
 DOCUMENTS should be a list of buffers (objects, not names),
 filenames or conses \(BUFFER-OR-FILENAME . PAGES\), where PAGES
 determines the scope of the search of the respective document.
-See `pdf-info-normalize-page-range' for it's format.
+See `pdf-info-normalize-page-range' for its format.
 
 STRING is either the string to search for or, if REGEXP-P is
 non-nil, a Perl compatible regular expression (PCRE).

--- a/lisp/pdf-outline.el
+++ b/lisp/pdf-outline.el
@@ -70,7 +70,7 @@
 (defcustom pdf-outline-display-labels nil
   "Whether the outline should display labels instead of page numbers.
 
-Usually a page's label is it's displayed page number."
+Usually a page's label is its displayed page number."
   :group 'pdf-outline
   :type 'boolean)
 
@@ -155,7 +155,7 @@ buffer.
   "View and traverse the outline of a PDF file.
 
 Press \\[pdf-outline-display-link] to display the PDF document,
-\\[pdf-outline-select-pdf-window] to select it's window,
+\\[pdf-outline-select-pdf-window] to select its window,
 \\[pdf-outline-move-to-current-page] to move to the outline item
 of the current page, \\[pdf-outline-follow-link] to goto the
 corresponding page or \\[pdf-outline-follow-link-and-quit] to
@@ -313,7 +313,7 @@ Open nodes as necessary."
     (pdf-outline-move-to-page page)))
 
 (defun pdf-outline-quit-and-kill ()
-  "Quit browsing the outline and kill it's buffer."
+  "Quit browsing the outline and kill its buffer."
   (interactive)
   (pdf-outline-quit t))
 

--- a/lisp/pdf-sync.el
+++ b/lisp/pdf-sync.el
@@ -21,8 +21,8 @@
 ;;
 ;; The backward search uses a heuristic, which is pretty simple, but
 ;; effective: It extracts the text around the click-position in the
-;; PDF, normalizes it's whitespace, deletes certain notorious
-;; character and translates certain other character into their latex
+;; PDF, normalizes its whitespace, deletes certain notorious
+;; characters and translates certain other characters into their latex
 ;; equivalents.  This transformed text is split into a series of
 ;; token.  A similar operation is performed on the source code around
 ;; the position synctex points at.  These two sequences of token are
@@ -43,7 +43,7 @@
   :group 'pdf-tools)
 
 (defcustom pdf-sync-forward-display-pdf-key "C-c C-g"
-  "Key to jump from a TeX buffer to it's PDF file.
+  "Key to jump from a TeX buffer to its PDF file.
 
 This key is added to `TeX-source-correlate-method', when
 command `pdf-sync-minor-mode' is activated and this map is defined."
@@ -258,8 +258,8 @@ the exact location of the clicked-upon text in the PDF."
     (9830 "diamondsuit"))
   "Alist mapping PDF character to a list of LaTeX macro names.
 
-Adding a character here with it's LaTeX equivalent names allows
-the heuristic backward search to find it's location in the source
+Adding a character here with its LaTeX equivalent names allows
+the heuristic backward search to find its location in the source
 file.  These strings should not match
 `pdf-sync-backward-source-flush-regexp'.
 

--- a/server/epdfinfo.c
+++ b/server/epdfinfo.c
@@ -339,7 +339,7 @@ strchomp (char *str)
 }
 
 /**
- * Create a new, temporary file and returns it's name.
+ * Create a new, temporary file and returns its name.
  *
  * @return The filename.
  */
@@ -672,7 +672,7 @@ region_print (cairo_region_t *region, double width, double height)
  *
  * @param type The PopplerActionType.
  *
- * @return It's string representation.
+ * @return Its string representation.
  */
 static const char *
 xpoppler_action_type_string(PopplerActionType type)
@@ -699,7 +699,7 @@ xpoppler_action_type_string(PopplerActionType type)
  *
  * @param type The PopplerAnnotType.
  *
- * @return It's string representation.
+ * @return Its string representation.
  */
 static const char *
 xpoppler_annot_type_string (PopplerAnnotType type)
@@ -741,7 +741,7 @@ xpoppler_annot_type_string (PopplerAnnotType type)
  *
  * @param type The PopplerAnnotTextState.
  *
- * @return It's string representation.
+ * @return Its string representation.
  */
 static const char *
 xpoppler_annot_text_state_string (PopplerAnnotTextState state)


### PR DESCRIPTION
Minor language correction across the repository: the correct possessive with it is "its", not "it's".