### PR TITLE
Updated autobuild to fix error when using autobuild on Gentoo

### DIFF
--- a/server/autobuild
+++ b/server/autobuild
@@ -409,7 +409,7 @@ os_gentoo() {
     PKGCMD=emerge
     PKGARGS=--noreplace
     PACKAGES="app-text/poppler
-              dev-util/pkgconfig
+              dev-util/pkgconf
               media-libs/libpng
               sys-devel/autoconf
               sys-devel/automake


### PR DESCRIPTION
This fixes the autobuild failing on Gentoo if the user hasn't compiled [```dev-util/pkgconf```](https://packages.gentoo.org/packages/dev-util/pkgconf), it fails to build due to the [removed](https://www.mail-archive.com/gentoo-dev@lists.gentoo.org/msg93072.html) repository ```dev-util/pkgconfig```. When I replaced this, I managed to build everything. 